### PR TITLE
Slack 메시지 이모지 추가 및 가독성 개선

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(git checkout:*)",
       "Bash(gh issue close:*)",
       "Bash(git push:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(git cherry-pick:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,12 @@
       "Bash(gh issue close:*)",
       "Bash(git push:*)",
       "Bash(grep:*)",
-      "Bash(git cherry-pick:*)"
+      "Bash(git cherry-pick:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh issue:*)",
+      "Bash(timeout 60 npm run start)",
+      "Bash(node:*)",
+      "Bash(rm:*)"
     ],
     "deny": []
   }

--- a/src/__tests__/services/slackService.test.ts
+++ b/src/__tests__/services/slackService.test.ts
@@ -84,7 +84,14 @@ describe('SlackService', () => {
   });
 
   describe('formatDateTime', () => {
-    it('should format date string correctly', () => {
+    it('should format 12-digit date string correctly (KMA format)', () => {
+      const service = new SlackService(testWebhookUrl);
+      
+      const result = (service as any).formatDateTime('202508011530');
+      expect(result).toBe('2025-08-01 15:30');
+    });
+
+    it('should format ISO date string correctly', () => {
       const service = new SlackService(testWebhookUrl);
       
       // Mock toLocaleString to return predictable result
@@ -99,11 +106,11 @@ describe('SlackService', () => {
       (global.Date as any).mockRestore();
     });
 
-    it('should return formatted date for invalid dates that produce Invalid Date', () => {
+    it('should return original string for invalid dates', () => {
       const service = new SlackService(testWebhookUrl);
       
       const result = (service as any).formatDateTime('invalid-date');
-      expect(result).toBe('Invalid Date');
+      expect(result).toBe('invalid-date');
     });
 
     it('should return original string when toLocaleString throws an error', () => {
@@ -111,6 +118,7 @@ describe('SlackService', () => {
       
       // Date 생성자를 모킹해서 toLocaleString에서 에러가 발생하도록 설정
       const mockDate = {
+        getTime: jest.fn().mockReturnValue(NaN), // Invalid date
         toLocaleString: jest.fn().mockImplementation(() => {
           throw new Error('toLocaleString error');
         })
@@ -122,6 +130,13 @@ describe('SlackService', () => {
       expect(result).toBe('2025-08-01T15:30:00');
       
       (global.Date as any).mockRestore();
+    });
+
+    it('should handle non-numeric 12-character strings', () => {
+      const service = new SlackService(testWebhookUrl);
+      
+      const result = (service as any).formatDateTime('abcd12345678');
+      expect(result).toBe('abcd12345678');
     });
   });
 
@@ -173,9 +188,9 @@ describe('SlackService', () => {
           expect.objectContaining({
             title: expect.stringContaining('폭염'),
             fields: expect.arrayContaining([
-              { title: '지역', value: '서울강북', short: true },
-              { title: '특보수준', value: '2', short: true },
-              { title: '상위지역', value: '서울특별시', short: true }
+              { title: '📍 지역', value: '서울강북', short: true },
+              { title: '📊 특보수준', value: '주의보', short: true },
+              { title: '🏢 상위지역', value: '서울특별시', short: true }
             ])
           })
         ]
@@ -315,6 +330,315 @@ describe('SlackService', () => {
       mockFetch.mockResolvedValue({ ok: true });
 
       await slackService.sendMultipleAlerts(mockAlerts);
+
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
+    });
+  });
+
+  describe('getWarningLevel', () => {
+    it('should return correct Korean name for level codes', () => {
+      const service = new SlackService(testWebhookUrl);
+      
+      expect((service as any).getWarningLevel('1')).toBe('예비');
+      expect((service as any).getWarningLevel('2')).toBe('주의보');
+      expect((service as any).getWarningLevel('3')).toBe('경보');
+    });
+
+    it('should return original code for unknown level codes', () => {
+      const service = new SlackService(testWebhookUrl);
+      
+      expect((service as any).getWarningLevel('9')).toBe('9');
+    });
+
+    it('should handle trimmed codes', () => {
+      const service = new SlackService(testWebhookUrl);
+      
+      expect((service as any).getWarningLevel(' 2 ')).toBe('주의보');
+    });
+  });
+
+  describe('getChangeTypeConfig', () => {
+    it('should return correct config for each change type', () => {
+      const service = new SlackService(testWebhookUrl);
+      
+      expect((service as any).getChangeTypeConfig('NEW')).toEqual({
+        emoji: '🆕',
+        color: 'danger',
+        title: '신규 발표'
+      });
+      
+      expect((service as any).getChangeTypeConfig('RESOLVED')).toEqual({
+        emoji: '✅',
+        color: 'good',
+        title: '해제'
+      });
+      
+      expect((service as any).getChangeTypeConfig('LEVEL_UP')).toEqual({
+        emoji: '⬆️',
+        color: 'danger',
+        title: '수준 상향'
+      });
+      
+      expect((service as any).getChangeTypeConfig('LEVEL_DOWN')).toEqual({
+        emoji: '⬇️',
+        color: 'warning',
+        title: '수준 하향'
+      });
+      
+      expect((service as any).getChangeTypeConfig('TIME_EXTENDED')).toEqual({
+        emoji: '⏰',
+        color: 'warning',
+        title: '시간 연장'
+      });
+      
+      expect((service as any).getChangeTypeConfig('MODIFIED')).toEqual({
+        emoji: '🔄',
+        color: 'warning',
+        title: '내용 변경'
+      });
+    });
+  });
+
+  describe('sendAlertChange', () => {
+    it('should send NEW alert change successfully', async () => {
+      const mockChange = createMockAlertChange({
+        type: 'NEW',
+        current: createMockCachedAlert(),
+        description: '서울강북 폭염 주의보 신규 발표'
+      });
+      
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await slackService.sendAlertChange(mockChange);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        testWebhookUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: expect.stringContaining('🆕 기상특보 신규 발표')
+        })
+      );
+    });
+
+    it('should include correct payload for NEW change', async () => {
+      const mockChange = createMockAlertChange({
+        type: 'NEW',
+        current: createMockCachedAlert({
+          regionName: '서울강북',
+          warningType: 'H',
+          level: '2'
+        })
+      });
+      
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await slackService.sendAlertChange(mockChange);
+
+      const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(payload).toMatchObject({
+        text: '🆕 기상특보 신규 발표',
+        attachments: [
+          expect.objectContaining({
+            color: 'danger',
+            fields: expect.arrayContaining([
+              { title: '📍 지역', value: '서울강북', short: true },
+              { title: '⚠️ 특보종류', value: '폭염', short: true },
+              { title: '📊 특보수준', value: '주의보', short: true }
+            ])
+          })
+        ]
+      });
+    });
+
+    it('should send RESOLVED alert change successfully', async () => {
+      const mockChange = createMockAlertChange({
+        type: 'RESOLVED',
+        previous: createMockCachedAlert(),
+        current: undefined,
+        description: '서울강북 폭염 주의보 해제'
+      });
+      
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await slackService.sendAlertChange(mockChange);
+
+      const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(payload).toMatchObject({
+        text: '✅ 기상특보 해제',
+        attachments: [
+          expect.objectContaining({
+            color: 'good',
+            fields: expect.arrayContaining([
+              { title: '❌ 해제된 수준', value: '주의보', short: true }
+            ])
+          })
+        ]
+      });
+    });
+
+    it('should send LEVEL_UP alert change with level comparison', async () => {
+      const mockChange = createMockAlertChange({
+        type: 'LEVEL_UP',
+        previous: createMockCachedAlert({ level: '2' }),
+        current: createMockCachedAlert({ level: '3' }),
+        description: '서울강북 폭염 주의보 → 경보 수준 상향'
+      });
+      
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await slackService.sendAlertChange(mockChange);
+
+      const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(payload.attachments[0].fields).toContainEqual({
+        title: '📈 수준 변화',
+        value: '주의보 → 경보',
+        short: false
+      });
+    });
+
+    it('should send TIME_EXTENDED alert change with time comparison', async () => {
+      const mockChange = createMockAlertChange({
+        type: 'TIME_EXTENDED',
+        previous: createMockCachedAlert({ effectiveAt: '202508011600' }),
+        current: createMockCachedAlert({ effectiveAt: '202508011800' }),
+        description: '서울강북 폭염 주의보 발효시각 연장'
+      });
+      
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await slackService.sendAlertChange(mockChange);
+
+      const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(payload.attachments[0].fields).toContainEqual({
+        title: '⏳ 발효시각 변화',
+        value: expect.stringContaining('→'),
+        short: false
+      });
+    });
+
+    it('should handle missing alert data gracefully', async () => {
+      const mockChange = createMockAlertChange({
+        type: 'NEW',
+        current: undefined,
+        previous: undefined
+      });
+
+      await slackService.sendAlertChange(mockChange);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should handle Slack API errors for alert changes', async () => {
+      const mockChange = createMockAlertChange();
+      
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request'
+      });
+
+      await expect(slackService.sendAlertChange(mockChange)).rejects.toThrow(
+        'Slack 메시지 보내기 실패: 400 Bad Request'
+      );
+    });
+  });
+
+  describe('sendAlertChanges', () => {
+    it('should do nothing when no changes provided', async () => {
+      await slackService.sendAlertChanges([]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should send single change directly', async () => {
+      const mockChange = createMockAlertChange();
+      
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await slackService.sendAlertChanges([mockChange]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send multiple changes via sendMultipleAlertChanges', async () => {
+      const mockChanges = [
+        createMockAlertChange({ description: '서울강북 변동' }),
+        createMockAlertChange({ description: '서울강남 변동' })
+      ];
+      
+      mockFetch.mockResolvedValue({ ok: true });
+
+      await slackService.sendAlertChanges(mockChanges);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle errors gracefully', async () => {
+      const mockChange = createMockAlertChange();
+      
+      mockFetch.mockRejectedValueOnce(new Error('API Error'));
+
+      await expect(slackService.sendAlertChanges([mockChange])).rejects.toThrow('API Error');
+    });
+  });
+
+  describe('sendMultipleAlertChanges', () => {
+    beforeEach(() => {
+      // Mock setTimeout to avoid actual delays in tests
+      jest.spyOn(global, 'setTimeout').mockImplementation((callback: any) => {
+        callback();
+        return {} as any;
+      });
+    });
+
+    afterEach(() => {
+      (global.setTimeout as any).mockRestore();
+    });
+
+    it('should do nothing when no changes provided', async () => {
+      await slackService.sendMultipleAlertChanges([]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should send all changes with delays', async () => {
+      const mockChanges = [
+        createMockAlertChange({ description: '서울강북 변동' }),
+        createMockAlertChange({ description: '서울강남 변동' }),
+        createMockAlertChange({ description: '경기남부 변동' })
+      ];
+      
+      mockFetch.mockResolvedValue({ ok: true });
+
+      await slackService.sendMultipleAlertChanges(mockChanges);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(setTimeout).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle errors during multiple sends', async () => {
+      const mockChanges = [
+        createMockAlertChange({ description: '서울강북 변동' }),
+        createMockAlertChange({ description: '서울강남 변동' })
+      ];
+      
+      mockFetch
+        .mockResolvedValueOnce({ ok: true })
+        .mockRejectedValueOnce(new Error('Send error'));
+
+      await expect(slackService.sendMultipleAlertChanges(mockChanges)).rejects.toThrow('Send error');
+    });
+
+    it('should wait between sends to avoid rate limits', async () => {
+      const mockChanges = [
+        createMockAlertChange({ description: '서울강북 변동' }),
+        createMockAlertChange({ description: '서울강남 변동' })
+      ];
+      
+      mockFetch.mockResolvedValue({ ok: true });
+
+      await slackService.sendMultipleAlertChanges(mockChanges);
 
       expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
     });

--- a/src/services/slackService.ts
+++ b/src/services/slackService.ts
@@ -1,4 +1,4 @@
-import { WeatherAlert } from '../types/weather';
+import { WeatherAlert, AlertChange, AlertChangeType } from '../types/weather';
 import { logger } from '../utils/logger';
 
 export class SlackService {
@@ -11,6 +11,244 @@ export class SlackService {
     }
   }
 
+  /**
+   * 변동 유형별 메시지 설정을 반환합니다.
+   */
+  private getChangeTypeConfig(type: AlertChangeType) {
+    const configs = {
+      NEW: {
+        emoji: '🆕',
+        color: 'danger',
+        title: '신규 발표'
+      },
+      RESOLVED: {
+        emoji: '✅',
+        color: 'good',
+        title: '해제'
+      },
+      LEVEL_UP: {
+        emoji: '⬆️',
+        color: 'danger',
+        title: '수준 상향'
+      },
+      LEVEL_DOWN: {
+        emoji: '⬇️',
+        color: 'warning',
+        title: '수준 하향'
+      },
+      TIME_EXTENDED: {
+        emoji: '⏰',
+        color: 'warning',
+        title: '시간 연장'
+      },
+      MODIFIED: {
+        emoji: '🔄',
+        color: 'warning',
+        title: '내용 변경'
+      }
+    };
+    
+    return configs[type];
+  }
+
+  /**
+   * 특보 변동사항을 Slack으로 전송합니다.
+   */
+  async sendAlertChange(change: AlertChange): Promise<void> {
+    try {
+      const config = this.getChangeTypeConfig(change.type);
+      const alert = change.current || change.previous;
+      
+      if (!alert) {
+        logger.warn('AlertChange에 current나 previous 정보가 없습니다');
+        return;
+      }
+
+      const payload = {
+        text: `${config.emoji} 기상특보 ${config.title}`,
+        attachments: [
+          {
+            color: config.color,
+            title: change.description,
+            fields: [
+              {
+                title: '📍 지역',
+                value: alert.regionName,
+                short: true
+              },
+              {
+                title: '⚠️ 특보종류',
+                value: this.getWarningTypeName(alert.warningType),
+                short: true
+              }
+            ],
+            footer: '한국 기상청',
+            ts: Math.floor(Date.now() / 1000)
+          }
+        ]
+      };
+
+      // 변동 유형에 따른 추가 필드 설정
+      this.addChangeSpecificFields(payload.attachments[0], change);
+
+      const response = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Slack 메시지 보내기 실패: ${response.status} ${response.statusText}`);
+      }
+
+      logger.info(`Slack 변동 알림 전송 완료: ${change.type} - ${alert.regionName}`);
+    } catch (error) {
+      logger.error('Slack 변동 알림 전송 중 오류:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 여러 특보 변동사항을 Slack으로 전송합니다.
+   */
+  async sendAlertChanges(changes: AlertChange[]): Promise<void> {
+    if (changes.length === 0) {
+      return;
+    }
+
+    try {
+      if (changes.length === 1) {
+        await this.sendAlertChange(changes[0]);
+      } else {
+        await this.sendMultipleAlertChanges(changes);
+      }
+    } catch (error) {
+      logger.error('기상특보 변동 Slack 알림 전송 중 오류:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 여러 특보 변동사항을 순차적으로 전송합니다.
+   */
+  async sendMultipleAlertChanges(changes: AlertChange[]): Promise<void> {
+    if (changes.length === 0) {
+      return;
+    }
+
+    try {
+      for (const change of changes) {
+        await this.sendAlertChange(change);
+        // API 요청 제한을 피하기 위해 잠시 대기
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    } catch (error) {
+      logger.error('다중 Slack 변동 알림 전송 중 오류:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 변동 유형에 따른 추가 필드를 설정합니다.
+   */
+  private addChangeSpecificFields(attachment: any, change: AlertChange): void {
+    const alert = change.current || change.previous!;
+    
+    // 공통 필드들
+    attachment.fields.push(
+      {
+        title: '📢 발표시각',
+        value: this.formatDateTime(alert.announcedAt),
+        short: true
+      },
+      {
+        title: '⏰ 발효시각', 
+        value: this.formatDateTime(alert.effectiveAt),
+        short: true
+      }
+    );
+
+    // 변동 유형별 특수 처리
+    switch (change.type) {
+      case 'NEW':
+        if (change.current) {
+          attachment.fields.push({
+            title: '📊 특보수준',
+            value: this.getWarningLevel(change.current.level),
+            short: true
+          });
+        }
+        break;
+        
+      case 'RESOLVED':
+        if (change.previous) {
+          attachment.fields.push({
+            title: '❌ 해제된 수준',
+            value: this.getWarningLevel(change.previous.level),
+            short: true
+          });
+        }
+        break;
+        
+      case 'LEVEL_UP':
+      case 'LEVEL_DOWN':
+        if (change.previous && change.current) {
+          attachment.fields.push({
+            title: '📈 수준 변화',
+            value: `${this.getWarningLevel(change.previous.level)} → ${this.getWarningLevel(change.current.level)}`,
+            short: false
+          });
+        }
+        break;
+        
+      case 'TIME_EXTENDED':
+        if (change.previous && change.current) {
+          attachment.fields.push({
+            title: '⏳ 발효시각 변화',
+            value: `${this.formatDateTime(change.previous.effectiveAt)} → ${this.formatDateTime(change.current.effectiveAt)}`,
+            short: false
+          });
+        }
+        break;
+        
+      case 'MODIFIED':
+        if (change.current) {
+          attachment.fields.push({
+            title: '📊 현재 수준',
+            value: this.getWarningLevel(change.current.level),
+            short: true
+          });
+        }
+        break;
+    }
+  }
+
+  /**
+   * 특보 수준 코드를 한국어 이름으로 변환합니다.
+   */
+  private getWarningLevel(levelCode: string): string {
+    const levels: Record<string, string> = {
+      '1': '예비',
+      '2': '주의보',
+      '3': '경보'
+    };
+    return levels[levelCode.trim()] || levelCode;
+  }
+
+  private getWarningCommand(cmdCode: string): string {
+    const commands: Record<string, string> = {
+      '1': '발표',
+      '2': '대치',
+      '3': '해제',
+      '4': '대치해제(자동)',
+      '5': '연장',
+      '6': '변경',
+      '7': '변경해제'
+    };
+    return commands[cmdCode.trim()] || cmdCode;
+  }
   async sendAlert(alert: WeatherAlert): Promise<void> {
     try {
       
@@ -19,35 +257,35 @@ export class SlackService {
         attachments: [
           {
             color: alert.LVL === '1' ? 'danger' : 'warning',
-            title: `${this.getWarningTypeName(alert.WRN)} ${alert.CMD}`,
+            title: `${this.getWarningTypeName(alert.WRN)} ${this.getWarningCommand(alert.CMD)}`,
             fields: [
               {
-                title: '지역',
+                title: '📍 지역',
                 value: alert.REG_NAME,
                 short: true
               },
               {
-                title: '발령시각',
+                title: '📢 발령시각',
                 value: this.formatDateTime(alert.TM_FC),
                 short: true
               },
               {
-                title: '발효시각',
+                title: '⏰ 발효시각',
                 value: this.formatDateTime(alert.TM_EF),
                 short: true
               },
               {
-                title: '특보수준',
-                value: alert.LVL,
+                title: '📊 특보수준',
+                value: this.getWarningLevel(alert.LVL),
                 short: true
               },
               {
-                title: '상위지역',
+                title: '🏢 상위지역',
                 value: alert.REG_UP_KO || '알 수 없음',
                 short: true
               }
             ],
-            footer: '한국 기상청',
+            footer: '🌤️ 한국 기상청',
             ts: Math.floor(new Date(alert.TM_FC).getTime() / 1000)
           }
         ]
@@ -127,15 +365,31 @@ export class SlackService {
 
   private formatDateTime(dateTimeStr: string): string {
     try {
+      // YYYYMMDDHHMM 형태를 YYYY-MM-DD HH:MM 형태로 변환 (기상청 API 형식)
+      if (dateTimeStr.length === 12 && /^\d{12}$/.test(dateTimeStr)) {
+        const year = dateTimeStr.substring(0, 4);
+        const month = dateTimeStr.substring(4, 6);
+        const day = dateTimeStr.substring(6, 8);
+        const hour = dateTimeStr.substring(8, 10);
+        const minute = dateTimeStr.substring(10, 12);
+        return `${year}-${month}-${day} ${hour}:${minute}`;
+      }
+      
+      // ISO 형식이나 다른 형식 처리
       const date = new Date(dateTimeStr);
-      return date.toLocaleString('ko-KR', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        timeZone: 'Asia/Seoul'
-      });
+      if (!isNaN(date.getTime())) {
+        return date.toLocaleString('ko-KR', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZone: 'Asia/Seoul'
+        });
+      }
+      
+      // 변환할 수 없는 경우 원본 반환
+      return dateTimeStr;
     } catch {
       return dateTimeStr;
     }


### PR DESCRIPTION
## Summary
• Slack 알림 메시지에 이모지 추가하여 가독성 크게 향상
• KMA API 날짜 형식(YYYYMMDDHHMM) 처리 개선으로 "Invalid Date" 오류 해결
• 특보 명령 코드를 한국어로 표시하는 기능 추가

## 주요 변경사항
• **이모지 추가**: 📍 지역, ⚠️ 특보종류, 📊 특보수준, 📢 발표시각, ⏰ 발효시각 등
• **날짜 포맷 개선**: formatDateTime 메서드에서 12자리 KMA 날짜 형식 정확히 파싱
• **명령 코드 한국어화**: getWarningCommand 메서드 추가 (발표, 해제, 변경 등)
• **footer 이모지**: 🌤️ 한국 기상청으로 표시

## 개선된 이모지 목록
### 일반 특보 알림:
- 📍 지역
- 📢 발령시각
- ⏰ 발효시각  
- 📊 특보수준
- 🏢 상위지역
- 🌤️ 한국 기상청 (footer)

### 변동 알림 추가 필드:
- 📍 지역
- ⚠️ 특보종류
- 📢 발표시각
- ⏰ 발효시각
- 📊 특보수준 (신규/변경 시)
- ❌ 해제된 수준 (해제 시)
- 📈 수준 변화 (수준 변경 시)
- ⏳ 발효시각 변화 (시간 연장 시)

## Test plan
- [x] 모든 테스트 통과 확인 (138개 테스트)
- [x] SlackService 이모지 관련 테스트 업데이트
- [x] 날짜 포맷 테스트 케이스 추가 검증
- [x] getWarningCommand 메서드 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)