### PR TITLE
🚨 [HOTFIX] 지역 필터링 로직 버그 수정 (v1.0.1)

### DIFF
--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -60,9 +60,7 @@ export class WeatherService {
       // 지역 필터링
       if (targetRegIds.length > 0) {
         allAlerts = allAlerts.filter(alert => 
-          targetRegIds.some(regId => 
-            alert.REG_NAME.includes(regId) || alert.REG_KO.includes(regId)
-          )
+          targetRegIds.includes(alert.REG_ID)
         );
       }
 
@@ -99,9 +97,7 @@ export class WeatherService {
       // 지역 필터링
       if (targetRegIds.length > 0) {
         allAlerts = allAlerts.filter(alert => 
-          targetRegIds.some(regId => 
-            alert.REG_NAME.includes(regId) || alert.REG_KO.includes(regId)
-          )
+          targetRegIds.includes(alert.REG_ID)
         );
       }
 


### PR DESCRIPTION
## 🚨 긴급 버그 수정

### 🐛 문제점
v1.0.0에서 **TARGET_REGION_IDS 설정이 전혀 작동하지 않는** 심각한 버그 발견

#### 증상
- `TARGET_REGION_IDS=L1010800,L1011800,L1010700` 설정해도 특보 수신되지 않음
- 인천광역시, 파주시, 김포시 등 호우주의보 발생했지만 알림 없음
- 지역 필터링이 완전히 무효화됨

#### 원인 분석
```typescript
// 기존 버그 코드
alert.REG_NAME.includes(regId) || alert.REG_KO.includes(regId)
// "인천광역시".includes("L1010800") = false ❌

// 수정된 코드  
targetRegIds.includes(alert.REG_ID)
// ["L1010800"].includes("L1010800") = true ✅
```

### 🔧 수정 내용

#### Before
```typescript
allAlerts = allAlerts.filter(alert => 
  targetRegIds.some(regId => 
    alert.REG_NAME.includes(regId) || alert.REG_KO.includes(regId)
  )
);
```

#### After  
```typescript
allAlerts = allAlerts.filter(alert => 
  targetRegIds.includes(alert.REG_ID)
);
```

### ✅ 검증 결과
- **빌드 성공**: TypeScript 컴파일 오류 없음
- **로직 검증**: 지역코드 직접 매칭으로 정확성 확보
- **영향 범위**: weatherService.ts 2개 위치 모두 수정

### 📊 영향 분석
- **문제 심각도**: 🔴 Critical (핵심 기능 완전 무효화)
- **영향 사용자**: TARGET_REGION_IDS 사용하는 모든 사용자
- **데이터 누락**: 지정된 지역의 모든 특보 알림 누락
- **사용성**: 지역별 모니터링 기능 완전 실패

### 🎯 기대 효과
- ✅ 지역 필터링 정상 작동
- ✅ 설정한 지역의 특보만 정확히 수신
- ✅ 불필요한 전국 특보 알림 차단
- ✅ 사용자 설정 의도대로 동작

### 🚀 배포 계획
1. **즉시 배포**: v1.0.1 태그 생성
2. **운영 반영**: PRODUCTION 환경 업데이트
3. **사용자 알림**: 수정 사항 안내

---
**Priority**: 🔴 Critical  
**Type**: 🚨 Hotfix  
**Version**: v1.0.0 → v1.0.1  
**Reviewer**: @fomalhaut84

🤖 Generated with [Claude Code](https://claude.ai/code)