### PR TITLE
fix: 텔레그램 봇 EFATAL AggregateError 중복 폴링 오류 해결

### DIFF
--- a/src/__tests__/services/notifications/TelegramNotificationService.test.ts
+++ b/src/__tests__/services/notifications/TelegramNotificationService.test.ts
@@ -11,6 +11,8 @@ jest.mock('node-telegram-bot-api', () => {
     sendMessage: jest.fn().mockResolvedValue({ message_id: 123 }),
     answerCallbackQuery: jest.fn().mockResolvedValue(true),
     editMessageText: jest.fn().mockResolvedValue(true),
+    startPolling: jest.fn().mockResolvedValue(true),
+    isPolling: jest.fn().mockReturnValue(false),
     stopPolling: jest.fn().mockResolvedValue(true)
   }));
 });
@@ -79,6 +81,31 @@ describe('TelegramNotificationService', () => {
   describe('platformName', () => {
     it('should return telegram as platform name', () => {
       expect(service.platformName).toBe('telegram');
+    });
+  });
+
+  describe('initialize', () => {
+    it('should initialize bot successfully', async () => {
+      await service.initialize();
+      // Should not throw error
+    });
+
+    it('should handle concurrent initialization calls safely', async () => {
+      // 동시에 여러 번 초기화 호출
+      const promises = [
+        service.initialize(),
+        service.initialize(),
+        service.initialize()
+      ];
+
+      // 모든 호출이 성공적으로 완료되어야 함
+      await expect(Promise.all(promises)).resolves.not.toThrow();
+    });
+
+    it('should skip initialization if already initialized', async () => {
+      await service.initialize();
+      await service.initialize(); // 두 번째 호출은 건너뛰어야 함
+      // Should not throw error
     });
   });
 

--- a/src/__tests__/services/notifications/TelegramNotificationService.test.ts
+++ b/src/__tests__/services/notifications/TelegramNotificationService.test.ts
@@ -98,8 +98,8 @@ describe('TelegramNotificationService', () => {
         service.initialize()
       ];
 
-      // 모든 호출이 성공적으로 완료되어야 함
-      await expect(Promise.all(promises)).resolves.not.toThrow();
+      // 모든 호출이 성공적으로 완료되어야 함 (에러 없이 resolve)
+      await expect(Promise.all(promises)).resolves.toEqual([undefined, undefined, undefined]);
     });
 
     it('should skip initialization if already initialized', async () => {

--- a/src/services/notifications/TelegramNotificationService.ts
+++ b/src/services/notifications/TelegramNotificationService.ts
@@ -1,10 +1,9 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { NotificationService, NotificationResult, TelegramConfig } from './interfaces';
 import { WeatherAlert, AlertChange, AlertChangeType } from '../../types/weather';
-import { Config } from '../../config';
 import { logger } from '../../utils/logger';
 import { TelegramSubscriptionInterface } from '../subscriptions/TelegramSubscriptionInterface';
-import { SubscriptionCommandParams, SubscriptionCommandResult } from '../subscriptions/interfaces';
+import { SubscriptionCommandParams } from '../subscriptions/interfaces';
 import { SubscriptionManager } from './SubscriptionManager';
 
 export class TelegramNotificationService implements NotificationService {
@@ -36,9 +35,17 @@ export class TelegramNotificationService implements NotificationService {
   }
 
   async initialize(): Promise<void> {
+    // 이미 초기화되었으면 건너뛰기
+    if (this.isInitialized) {
+      logger.info('Telegram Bot already initialized, skipping...');
+      return;
+    }
+
     try {
-      // 수동으로 폴링 시작
-      await this.bot.startPolling();
+      // 수동으로 폴링 시작 (중복 방지)
+      if (!this.bot.isPolling()) {
+        await this.bot.startPolling();
+      }
 
       const me = await this.bot.getMe();
       logger.info(`Telegram Bot initialized: @${me.username}`);
@@ -495,8 +502,13 @@ _한국 기상청_`;
 
   async stop(): Promise<void> {
     try {
-      await this.bot.stopPolling();
-      logger.info('Telegram Bot stopped successfully');
+      if (this.bot.isPolling()) {
+        await this.bot.stopPolling({ cancel: true, reason: 'Service stopped' });
+        this.isInitialized = false;
+        logger.info('Telegram Bot stopped successfully');
+      } else {
+        logger.info('Telegram Bot was not polling, nothing to stop');
+      }
     } catch (error) {
       logger.error('Error stopping Telegram Bot:', error);
     }

--- a/src/services/notifications/TelegramNotificationService.ts
+++ b/src/services/notifications/TelegramNotificationService.ts
@@ -13,6 +13,7 @@ export class TelegramNotificationService implements NotificationService {
   private subscriptionInterface: TelegramSubscriptionInterface;
   private subscriptionManager: SubscriptionManager;
   private isInitialized: boolean = false;
+  private initializationPromise: Promise<void> | null = null;
 
   constructor(private config: TelegramConfig) {
     // 수동 폴링 제어로 409 Conflict 방지
@@ -41,6 +42,24 @@ export class TelegramNotificationService implements NotificationService {
       return;
     }
 
+    // 초기화가 진행 중이면 기존 Promise 재사용 (직렬화)
+    if (this.initializationPromise) {
+      logger.info('Telegram Bot initialization already in progress, waiting...');
+      return this.initializationPromise;
+    }
+
+    // 새로운 초기화 프로세스 시작
+    this.initializationPromise = this.doInitialize();
+
+    try {
+      await this.initializationPromise;
+    } finally {
+      // 초기화 완료 또는 실패 후 Promise 정리
+      this.initializationPromise = null;
+    }
+  }
+
+  private async doInitialize(): Promise<void> {
     try {
       // 수동으로 폴링 시작 (중복 방지)
       if (!this.bot.isPolling()) {


### PR DESCRIPTION
## 개요
텔레그램 봇에서 발생하는 `EFATAL: AggregateError` 오류를 해결하기 위해 중복 폴링 방지 로직을 추가했습니다.

## 문제 상황
```
[2025-10-23T02:40:45.021Z] ERROR: Telegram Bot polling error: {
  "code": "EFATAL",
  "message": "EFATAL: AggregateError"
}
```

### 원인 분석
- 동일한 봇 토큰으로 여러 인스턴스가 동시에 폴링을 시도
- `initialize()` 메서드가 중복 호출되면서 폴링이 여러 번 시작됨
- `healthCheck()` 메서드에서도 초기화를 시도하여 중복 가능성
- 서버 재시작 시 이전 폴링이 정리되지 않은 상태에서 새로운 폴링 시도

## 주요 변경사항

### 1. `initialize()` 메서드 개선
```typescript
async initialize(): Promise<void> {
  // 이미 초기화되었으면 건너뛰기
  if (this.isInitialized) {
    logger.info('Telegram Bot already initialized, skipping...');
    return;
  }

  try {
    // 수동으로 폴링 시작 (중복 방지)
    if (!this.bot.isPolling()) {
      await this.bot.startPolling();
    }
    // ... 나머지 코드
  }
}
```
- `isInitialized` 플래그 확인으로 중복 초기화 방지
- `bot.isPolling()` 체크로 이미 폴링 중이면 건너뛰기

### 2. `stop()` 메서드 강화
```typescript
async stop(): Promise<void> {
  try {
    if (this.bot.isPolling()) {
      await this.bot.stopPolling({ cancel: true, reason: 'Service stopped' });
      this.isInitialized = false;
      logger.info('Telegram Bot stopped successfully');
    } else {
      logger.info('Telegram Bot was not polling, nothing to stop');
    }
  } catch (error) {
    logger.error('Error stopping Telegram Bot:', error);
  }
}
```
- `bot.isPolling()` 확인 후 안전하게 종료
- `isInitialized` 상태 초기화
- 명시적인 종료 이유 추가

### 3. 코드 정리
- 사용하지 않는 import 제거 (`Config`, `SubscriptionCommandResult`)

## 테스트 계획
- [ ] 로컬 환경에서 봇 초기화 및 폴링 시작 확인
- [ ] 서버 재시작 시 중복 폴링 오류 미발생 확인
- [ ] `healthCheck()` 호출 시 중복 초기화 방지 확인
- [ ] 봇 종료 시 정상적으로 폴링 중지 확인

## 관련 이슈
- 관련 PR: #48 (텔레그램 봇 409 Conflict 해결)

## Breaking Changes
없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)