### PR TITLE
feat: 날씨 예보 API 에러 핸들링 강화 (#91 Phase 2)

### DIFF
--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -1367,11 +1367,73 @@ export class WeatherService {
   }
 
   /**
+   * 타임아웃과 재시도를 지원하는 fetch
+   * @param url 요청 URL
+   * @param options fetch 옵션
+   * @param maxRetries 최대 재시도 횟수
+   * @param timeout 타임아웃 (ms)
+   * @returns Response
+   */
+  private async fetchWithRetry(
+    url: string,
+    options: RequestInit = {},
+    maxRetries: number = 3,
+    timeout: number = 10000
+  ): Promise<Response> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        // AbortController로 타임아웃 구현
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+        const response = await fetch(url, {
+          ...options,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        // 성공 또는 4xx 에러는 재시도 없이 반환
+        if (response.ok || (response.status >= 400 && response.status < 500)) {
+          return response;
+        }
+
+        // 5xx 에러는 재시도
+        lastError = new Error(`HTTP ${response.status}: ${response.statusText}`);
+        logger.warn(`API 호출 실패 (시도 ${attempt + 1}/${maxRetries}): ${lastError.message}`);
+
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          lastError = new Error(`요청 타임아웃 (${timeout}ms)`);
+        } else {
+          lastError = error instanceof Error ? error : new Error(String(error));
+        }
+
+        logger.warn(`API 호출 실패 (시도 ${attempt + 1}/${maxRetries}): ${lastError.message}`);
+      }
+
+      // 마지막 시도가 아니면 대기 후 재시도 (exponential backoff)
+      if (attempt < maxRetries - 1) {
+        const delay = Math.min(1000 * Math.pow(2, attempt), 5000); // 최대 5초
+        logger.debug(`${delay}ms 후 재시도...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+
+    // 모든 재시도 실패
+    throw lastError || new Error('알 수 없는 오류');
+  }
+
+  /**
    * 초단기예보 데이터 조회
    * @param regionId 지역 코드 (특보구역 코드)
    * @returns 날씨 예보 데이터
    */
   async getWeatherForecast(regionId: string): Promise<WeatherForecast | null> {
+    const startTime = Date.now();
+
     try {
       // 1. 격자 좌표 조회 (CSV 우선, 하드코딩 fallback)
       const gridInfo = this.getGridCoordinates(regionId);
@@ -1401,9 +1463,9 @@ export class WeatherService {
       });
 
       const url = `${this.forecastUrl}?${params.toString()}`;
-      logger.debug(`초단기예보 API 호출: ${url}`);
+      logger.debug(`초단기예보 API 호출: ${url.replace(this.authKey, '***')}`); // authKey 마스킹
 
-      const response = await fetch(url);
+      const response = await this.fetchWithRetry(url);
       if (!response.ok) {
         throw new Error(`API 호출 실패: ${response.status} ${response.statusText}`);
       }
@@ -1431,11 +1493,16 @@ export class WeatherService {
         return null;
       }
 
-      logger.info(`지역 ${gridInfo.name}(${regionId})의 날씨 예보 조회 성공`);
+      const elapsedTime = Date.now() - startTime;
+      logger.info(`지역 ${gridInfo.name}(${regionId})의 날씨 예보 조회 성공 (${elapsedTime}ms)`);
       return forecast;
     } catch (error) {
+      const elapsedTime = Date.now() - startTime;
       // 날씨 예보는 필수 기능이 아니므로 warn 레벨로 로깅
-      logger.warn(`날씨 예보 조회 실패 (지역: ${regionId}):`, error instanceof Error ? error.message : String(error));
+      logger.warn(
+        `날씨 예보 조회 실패 (지역: ${regionId}, 소요시간: ${elapsedTime}ms):`,
+        error instanceof Error ? error.message : String(error)
+      );
       return null;
     }
   }


### PR DESCRIPTION
# 날씨 예보 API 에러 핸들링 강화

Issue #91의 Phase 2 구현입니다.

## 🎯 구현 내용

### 1. 타임아웃 기능 ⏱️
- **AbortController** 사용
- 기본 타임아웃: **10초**
- 타임아웃 시 명확한 에러 메시지 제공

### 2. 재시도 로직 🔄
- 최대 재시도 횟수: **3회**
- **Exponential backoff**: 1초 → 2초 → 4초 (최대 5초)
- **스마트 재시도**: 
  - 5xx 에러 → 재시도 ✅
  - 4xx 에러 → 재시도 안 함 ❌
  - 타임아웃 → 재시도 ✅

### 3. 에러 로깅 강화 📊
- API 호출 시도 횟수 로깅
- 재시도 대기 시간 로깅
- 응답 시간 측정 및 로깅 (성공/실패)
- **authKey 마스킹** (보안)

## 📝 주요 변경사항

### fetchWithRetry 메서드 추가

```typescript
private async fetchWithRetry(
  url: string,
  options: RequestInit = {},
  maxRetries: number = 3,
  timeout: number = 10000
): Promise<Response>
```

**기능**:
- AbortController로 타임아웃 구현
- Exponential backoff로 재시도 간격 조절
- 5xx 에러와 네트워크 오류만 재시도

### 개선된 로깅

#### 성공 시
```
날씨 예보 조회 성공 (123ms)
```

#### 실패 시
```
날씨 예보 조회 실패 (지역: L1100000, 소요시간: 456ms): HTTP 500
API 호출 실패 (시도 2/3): 요청 타임아웃 (10000ms)
1000ms 후 재시도...
```

#### 보안
```
초단기예보 API 호출: https://apihub.kma.go.kr/...?authKey=***
```

## ✅ 테스트 결과

### 백엔드
```
✅ TypeScript 빌드 성공
✅ 361개 테스트 모두 통과
```

### 프론트엔드
```
✅ Next.js 빌드 성공
```

## 🎁 기대 효과

### 안정성 향상
- 일시적 네트워크 오류 자동 복구
- 타임아웃으로 무한 대기 방지
- 불필요한 재시도 방지 (4xx 에러)

### 운영 편의성
- 상세한 에러 로그로 문제 진단 용이
- 응답 시간 측정으로 성능 모니터링 가능
- API 키 노출 방지

### 사용자 경험
- 일시적 장애 시 자동 복구로 서비스 지속성 향상
- 빠른 실패 (4xx) vs 재시도 (5xx) 구분

## 📋 변경 파일

- `src/services/weatherService.ts`
  - `fetchWithRetry()` 메서드 추가
  - `getWeatherForecast()` 로깅 개선

## 🔗 관련 이슈

Part of #91 (Phase 2: 개선)

## 📌 다음 단계

**Phase 3: 테스트**
- [ ] 단위 테스트 작성 (`getWeatherForecast`, `parseForecastData`)
- [ ] 통합 테스트 작성 (`/api/forecast/:regionId`)

---

**리뷰 포인트**:
- 타임아웃 10초가 적절한지
- Exponential backoff 간격이 적절한지
- 로깅 레벨이 적절한지