### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,5 +1,7 @@
 # 주간 보안 스캔 및 PR 보안 체크
 name: Security Scan
+permissions:
+  contents: read
 
 on:
   # 매주 월요일 오전 9시에 자동 실행


### PR DESCRIPTION
Potential fix for [https://github.com/fomalhaut84/ku-weather/security/code-scanning/1](https://github.com/fomalhaut84/ku-weather/security/code-scanning/1)

To fix this issue, you should add an explicit `permissions` block to the workflow or jobs in `.github/workflows/security-scan.yml`. The minimal safe setting is to assign `contents: read`, which gives the jobs access to read the repository contents (enough for actions/checkout and audit) but prevents write operations, adhering to least privilege principles. Since no job in this workflow seems to need write access to any resource, place the block at the workflow root, so it applies to every job unless overridden. **Insert this block just beneath the `name:` field and above `on:`**, following the YAML structure and indentation conventions. No further methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
