### PR TITLE
fix: 타입 안전성 강화 및 npm 취약점 패치 (#117)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -620,21 +620,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@cypress/request/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -6674,16 +6659,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/request/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "js-yaml": "^4.1.1",
     "form-data": "^4.0.1",
     "tough-cookie": "^5.0.0",
-    "test-exclude": "^7.0.1"
+    "test-exclude": "^7.0.1",
+    "qs": "^6.14.1"
   }
 }

--- a/src/examples/hybrid-subscription-demo.ts
+++ b/src/examples/hybrid-subscription-demo.ts
@@ -164,7 +164,7 @@ export class HybridSubscriptionDemo {
       logger.info(`웹 구독 현황: ${subscriptions.length}개 구독`);
       
       // 5. 구독 통계 조회
-      const stats = await webInterface.getSubscriptionStats(telegramToken.token);
+      const stats = await webInterface.getSubscriptionStats(telegramToken.token) as Record<string, Record<string, unknown>> | null;
       logger.info(`웹 구독 통계:`, {
         전체구독자: stats?.overall?.totalSubscriptions,
         사용자구독: stats?.user?.hasSubscription

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,21 +96,25 @@ async function main() {
     const webInterface = new WebSubscriptionInterface(subscriptionManager, tokenService);
 
     // 모든 플랫폼 서비스에 WebInterface 주입
+    interface WebInterfaceAware {
+      setWebInterface(webInterface: WebSubscriptionInterface): void;
+    }
+
     const telegramService = notificationService.getService('telegram');
     if (telegramService && 'setWebInterface' in telegramService) {
-      (telegramService as any).setWebInterface(webInterface);
+      (telegramService as unknown as WebInterfaceAware).setWebInterface(webInterface);
       logger.info('Telegram 서비스에 WebInterface 주입 완료');
     }
 
     const slackService = notificationService.getService('slack');
     if (slackService && 'setWebInterface' in slackService) {
-      (slackService as any).setWebInterface(webInterface);
+      (slackService as unknown as WebInterfaceAware).setWebInterface(webInterface);
       logger.info('Slack 서비스에 WebInterface 주입 완료');
     }
 
     const emailService = notificationService.getService('email');
     if (emailService && 'setWebInterface' in emailService) {
-      (emailService as any).setWebInterface(webInterface);
+      (emailService as unknown as WebInterfaceAware).setWebInterface(webInterface);
       logger.info('Email 서비스에 WebInterface 주입 완료');
     }
 

--- a/src/routes/alertRoutes.ts
+++ b/src/routes/alertRoutes.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { databaseService } from '../services/DatabaseService';
 import { logger } from '../utils/logger';
+import { AlertFilters } from '../types/api';
+import { AlertChangeType } from '../types/weather';
 
 const router = Router();
 
@@ -42,7 +44,7 @@ router.get('/current', async (req: Request, res: Response) => {
       });
     }
 
-    const filters: any = {};
+    const filters: AlertFilters = {};
     if (regionId) filters.regionId = regionId as string;
     if (warningType) filters.warningType = warningType as string;
     if (warningLevel) filters.warningLevel = warningLevel as string;
@@ -132,13 +134,19 @@ router.get('/history', async (req: Request, res: Response) => {
       });
     }
 
-    const filters: any = {
+    const filters: {
+      startDate: Date;
+      endDate: Date;
+      regionId?: string;
+      warningType?: string;
+      changeType?: AlertChangeType;
+    } = {
       startDate: start,
       endDate: end
     };
     if (regionId) filters.regionId = regionId as string;
     if (warningType) filters.warningType = warningType as string;
-    if (changeType) filters.changeType = changeType as string;
+    if (changeType) filters.changeType = changeType as AlertChangeType;
 
     const histories = await databaseService.getAlertHistory(filters);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -159,7 +159,7 @@ export class HttpServer {
         }
 
         // 업데이트 처리 (비동기, 응답은 즉시 반환)
-        (telegramService as any).processWebhookUpdate(update)
+        (telegramService as unknown as { processWebhookUpdate(update: unknown): Promise<void> }).processWebhookUpdate(update)
           .catch((error: Error) => {
             logger.error('Error in background webhook processing:', error);
           });

--- a/src/services/DatabaseService.ts
+++ b/src/services/DatabaseService.ts
@@ -386,24 +386,25 @@ export class DatabaseService {
     startDate: Date;
     endDate: Date;
     groupBy: 'region' | 'warningType' | 'level';
-  }): Promise<any[]> {
+  }): Promise<Record<string, unknown>[]> {
     try {
-      let groupByField: any;
+      type AlertHistoryGroupByField = 'upperRegion' | 'warningType' | 'warningLevel';
+      let groupByKey: AlertHistoryGroupByField;
 
       switch (filters.groupBy) {
         case 'region':
-          groupByField = { upperRegion: true };
+          groupByKey = 'upperRegion';
           break;
         case 'warningType':
-          groupByField = { warningType: true };
+          groupByKey = 'warningType';
           break;
         case 'level':
-          groupByField = { warningLevel: true };
+          groupByKey = 'warningLevel';
           break;
       }
 
       const stats = await this.prisma.alertHistory.groupBy({
-        by: Object.keys(groupByField) as any,
+        by: [groupByKey],
         where: {
           timestamp: {
             gte: filters.startDate,

--- a/src/services/notifications/MultiplatformNotificationService.ts
+++ b/src/services/notifications/MultiplatformNotificationService.ts
@@ -3,6 +3,7 @@ import { logger } from '../../utils/logger';
 import { NotificationService, NotificationResult } from './interfaces';
 import { SubscriptionManager, UserSubscription, SubscriptionNotificationResult } from './SubscriptionManager';
 import { HybridSubscriptionManager } from '../subscriptions/HybridSubscriptionManager';
+import { SubscriptionCommand } from '../subscriptions/interfaces';
 
 /**
  * 다중 플랫폼 알림 관리 서비스
@@ -570,7 +571,7 @@ export class MultiplatformNotificationService {
 
     try {
       const result = await this.hybridManager.processCommand({
-        command: command as any,
+        command: command as SubscriptionCommand,
         platform,
         userId,
         args,

--- a/src/services/notifications/SlackNotificationService.ts
+++ b/src/services/notifications/SlackNotificationService.ts
@@ -2,6 +2,7 @@ import { WeatherAlert, AlertChange, AlertChangeType, WeatherForecast } from '../
 import { logger } from '../../utils/logger';
 import { NotificationService, NotificationResult, SlackConfig } from './interfaces';
 import { WeatherService } from '../weatherService';
+import { SlackAttachment, SlackAttachmentField, SlackPayload, ChangeTypeConfig } from '../../types/api';
 
 /**
  * Slack 알림 서비스
@@ -150,7 +151,7 @@ export class SlackNotificationService implements NotificationService {
     const startTime = Date.now();
 
     try {
-      const attachments: any[] = [];
+      const attachments: SlackAttachment[] = [];
       let addedWeatherInfo = false;
 
       for (let i = 0; i < changes.length; i++) {
@@ -209,7 +210,7 @@ export class SlackNotificationService implements NotificationService {
   /**
    * 날씨 예보 정보를 Slack 필드로 포맷팅
    */
-  private formatWeatherField(forecast: WeatherForecast): any | null {
+  private formatWeatherField(forecast: WeatherForecast): SlackAttachmentField | null {
     const parts: string[] = [];
 
     if (forecast.temperature !== undefined) {
@@ -261,7 +262,7 @@ export class SlackNotificationService implements NotificationService {
   /**
    * Slack API로 페이로드 전송
    */
-  private async sendToSlack(payload: any): Promise<Response> {
+  private async sendToSlack(payload: SlackPayload): Promise<Response> {
     return await fetch(this.webhookUrl, {
       method: 'POST',
       headers: {
@@ -366,10 +367,10 @@ export class SlackNotificationService implements NotificationService {
   /**
    * 변동 알림용 Attachment 생성
    */
-  private createChangeAttachment(change: AlertChange, config: any) {
+  private createChangeAttachment(change: AlertChange, config: ChangeTypeConfig): SlackAttachment {
     const alert = change.current || change.previous!;
-    
-    const attachment: any = {
+
+    const attachment: SlackAttachment = {
       color: config.color,
       title: `${config.emoji} ${change.description}`,
       fields: [
@@ -415,10 +416,10 @@ export class SlackNotificationService implements NotificationService {
   /**
    * 배치 전송용 Attachment 생성
    */
-  private createBatchChangeAttachment(change: AlertChange, config: any, isLast: boolean) {
+  private createBatchChangeAttachment(change: AlertChange, config: ChangeTypeConfig, isLast: boolean): SlackAttachment {
     const alert = change.current || change.previous!;
-    
-    const attachment: any = {
+
+    const attachment: SlackAttachment = {
       color: config.color,
       title: `${config.emoji} ${change.description}`,
       fields: [

--- a/src/services/notifications/TelegramNotificationService.ts
+++ b/src/services/notifications/TelegramNotificationService.ts
@@ -12,7 +12,7 @@ import {
 } from '../../utils/messageFormatter';
 import { groupAlertChanges, getLevelName, getLevelEmoji, formatRegionList } from '../../utils/messageGrouper';
 import { TelegramSubscriptionInterface } from '../subscriptions/TelegramSubscriptionInterface';
-import { SubscriptionCommandParams } from '../subscriptions/interfaces';
+import { SubscriptionCommandParams, SubscriptionCommand } from '../subscriptions/interfaces';
 import { SubscriptionManager } from './SubscriptionManager';
 import { WeatherService } from '../weatherService';
 
@@ -157,7 +157,7 @@ export class TelegramNotificationService implements NotificationService {
     const params: SubscriptionCommandParams = {
       platform: 'telegram',
       userId: chatId, // Use chatId for group chat support
-      command: command as any,
+      command: command as SubscriptionCommand,
       args,
       rawMessage: msg.text
     };
@@ -188,7 +188,7 @@ export class TelegramNotificationService implements NotificationService {
       const commandParams: SubscriptionCommandParams = {
         platform: 'telegram',
         userId: chatId, // Use chatId for group chat support
-        command: action as any,
+        command: action as SubscriptionCommand,
         args: params,
         rawMessage: query.data
       };
@@ -725,7 +725,7 @@ _한국 기상청_`;
   /**
    * WebSubscriptionInterface 설정 (나중에 주입)
    */
-  setWebInterface(webInterface: any): void {
+  setWebInterface(webInterface: import('../subscriptions/WebSubscriptionInterface').WebSubscriptionInterface): void {
     this.subscriptionInterface.setWebInterface(webInterface);
     logger.info('TelegramNotificationService에 WebInterface 연결 완료');
   }

--- a/src/services/notifications/interfaces.ts
+++ b/src/services/notifications/interfaces.ts
@@ -81,7 +81,7 @@ export interface NotificationService {
    * @param message 전송할 메시지 내용
    * @param options 추가 옵션 (플랫폼별)
    */
-  sendDirectMessage?(userId: string, message: string, options?: any): Promise<NotificationResult>;
+  sendDirectMessage?(userId: string, message: string, options?: Record<string, unknown>): Promise<NotificationResult>;
 }
 
 /**
@@ -90,7 +90,7 @@ export interface NotificationService {
 export interface PlatformConfig {
   enabled: boolean;
   targetRegions?: string[]; // 플랫폼별 모니터링 대상 지역 (없으면 전역 설정 사용)
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/src/services/slackService.ts
+++ b/src/services/slackService.ts
@@ -1,7 +1,7 @@
 import { WeatherAlert, AlertChange, AlertChangeType } from '../types/weather';
 import { logger } from '../utils/logger';
 import { config } from '../config';
-import { SlackAttachment, SlackAttachmentField } from '../types/api';
+import { SlackAttachment } from '../types/api';
 import {
   formatDateTime,
   getWarningTypeName,

--- a/src/services/slackService.ts
+++ b/src/services/slackService.ts
@@ -1,6 +1,7 @@
 import { WeatherAlert, AlertChange, AlertChangeType } from '../types/weather';
 import { logger } from '../utils/logger';
 import { config } from '../config';
+import { SlackAttachment, SlackAttachmentField } from '../types/api';
 import {
   formatDateTime,
   getWarningTypeName,
@@ -199,7 +200,7 @@ export class SlackService {
     try {
       // 그루핑 로직 적용
       const groupedAlerts = groupAlertChanges(changes);
-      const attachments: any[] = [];
+      const attachments: SlackAttachment[] = [];
 
       // 수준별로 섹션 헤더 추가
       let currentLevel = '';
@@ -217,7 +218,8 @@ export class SlackService {
           attachments.push({
             color: group.level === '3' ? '#ff0000' : group.level === '2' ? '#ff9900' : '#ffcc00',
             text: `${levelEmoji} *${levelName}*`,
-            mrkdwn_in: ['text']
+            mrkdwn_in: ['text'],
+            fields: []
           });
         }
 
@@ -232,10 +234,11 @@ export class SlackService {
         const levelName = getLevelName(group.level);
 
         // 그룹 정보를 하나의 attachment로 표시
-        const attachment: any = {
+        const attachment: SlackAttachment = {
           color: changeConfig.color,
           text: `${changeConfig.emoji} *${warningEmoji} ${warningName}${levelName} ${this.getChangeTypeText(group.changeType)}*\n${regionTexts.join(', ')}`,
           mrkdwn_in: ['text'],
+          fields: [],
           footer: i === groupedAlerts.length - 1 ? '한국 기상청' : '',
           ts: i === groupedAlerts.length - 1 ? Math.floor(Date.now() / 1000) : undefined
         };
@@ -320,7 +323,7 @@ export class SlackService {
   /**
    * 배치 메시지용 간소화된 필드를 설정합니다.
    */
-  private addBatchedChangeFields(attachment: any, change: AlertChange): void {
+  private addBatchedChangeFields(attachment: SlackAttachment, change: AlertChange): void {
     // 배치 메시지에서는 핵심 정보만 표시
     switch (change.type) {
       case 'NEW':
@@ -379,7 +382,7 @@ export class SlackService {
   /**
    * 변동 유형에 따른 추가 필드를 설정합니다. (개별 메시지용)
    */
-  private addChangeSpecificFields(attachment: any, change: AlertChange): void {
+  private addChangeSpecificFields(attachment: SlackAttachment, change: AlertChange): void {
     const alert = change.current || change.previous!;
     
     // 공통 필드들

--- a/src/services/subscriptions/CommandParser.ts
+++ b/src/services/subscriptions/CommandParser.ts
@@ -12,6 +12,7 @@ import {
   RegionMapping,
   WarningTypeMapping
 } from './interfaces';
+import { UserSubscription } from '../notifications/SubscriptionManager';
 
 /**
  * 지역 코드 매핑 (사용자 친화적 이름)
@@ -206,12 +207,12 @@ export class CommonCommandParser implements BotCommandParser {
   /**
    * 구독 설정 요약 메시지 생성
    */
-  formatSubscriptionSummary(subscription: any): string {
+  formatSubscriptionSummary(subscription: UserSubscription): string {
     const regions = subscription.targetRegions?.length > 0 
       ? subscription.targetRegions.map((code: string) => this.getRegionName(code)).join(', ')
       : '전국';
     
-    const warnings = subscription.warningTypes?.length > 0
+    const warnings = (subscription.warningTypes && subscription.warningTypes.length > 0)
       ? subscription.warningTypes.map((code: string) => this.getWarningTypeName(code)).join(', ')
       : '전체';
     

--- a/src/services/subscriptions/EmailCommandProcessor.ts
+++ b/src/services/subscriptions/EmailCommandProcessor.ts
@@ -33,13 +33,13 @@ export class EmailCommandProcessor implements PlatformSubscriptionInterface, IEm
 
   private subscriptionManager: SubscriptionManager;
   private commandParser: CommonCommandParser;
-  private smtpConfig?: any;
+  private smtpConfig?: Record<string, unknown>;
   private webInterface?: WebSubscriptionInterface;
   private webDashboardUrl: string;
 
   constructor(
     subscriptionManager: SubscriptionManager,
-    smtpConfig?: any,
+    smtpConfig?: Record<string, unknown>,
     webInterface?: WebSubscriptionInterface,
     webDashboardUrl: string = 'https://weather.starryjeju.net'
   ) {

--- a/src/services/subscriptions/SlackInteractiveInterface.ts
+++ b/src/services/subscriptions/SlackInteractiveInterface.ts
@@ -20,7 +20,7 @@ import { WebSubscriptionInterface } from './WebSubscriptionInterface';
 /**
  * Slack 버튼 액션 페이로드
  */
-interface SlackButtonPayload {
+interface SlackButtonPayload extends Record<string, unknown> {
   type: string;
   user: { id: string; name?: string };
   channel: { id: string; name?: string };
@@ -31,7 +31,7 @@ interface SlackButtonPayload {
   }>;
   callback_id: string;
   team: { id: string; domain: string };
-  original_message: any;
+  original_message: Record<string, unknown>;
   response_url: string;
   trigger_id: string;
 }
@@ -42,8 +42,8 @@ interface SlackButtonPayload {
 interface SlackMessageBlock {
   type: string;
   text?: { type: string; text: string };
-  accessory?: any;
-  elements?: any[];
+  accessory?: Record<string, unknown>;
+  elements?: Record<string, unknown>[];
 }
 
 /**
@@ -119,7 +119,7 @@ export class SlackInteractiveInterface implements PlatformSubscriptionInterface,
   /**
    * 구독 설정용 인터랙티브 메시지 생성
    */
-  async createSubscriptionMessage(userId: string, currentSettings?: UserSubscription): Promise<any> {
+  async createSubscriptionMessage(userId: string, currentSettings?: UserSubscription): Promise<Record<string, unknown>> {
     try {
       const webToken = await this.generateWebToken(userId);
       const hasSubscription = !!currentSettings;
@@ -274,7 +274,7 @@ export class SlackInteractiveInterface implements PlatformSubscriptionInterface,
   /**
    * 설정 변경 확인 메시지 생성
    */
-  createConfirmationMessage(result: SubscriptionCommandResult): any {
+  createConfirmationMessage(result: SubscriptionCommandResult): Record<string, unknown> {
     const emoji = result.success ? '✅' : '❌';
     const color = result.success ? 'good' : 'danger';
 
@@ -298,7 +298,7 @@ export class SlackInteractiveInterface implements PlatformSubscriptionInterface,
   /**
    * 특보 알림과 함께 구독 설정 버튼 추가
    */
-  enhanceAlertMessageWithSubscription(alertMessage: any, userId?: string): any {
+  enhanceAlertMessageWithSubscription(alertMessage: Record<string, unknown>, userId?: string): Record<string, unknown> {
     if (!userId) return alertMessage;
 
     const subscriptionBlock = {
@@ -314,12 +314,12 @@ export class SlackInteractiveInterface implements PlatformSubscriptionInterface,
     };
 
     // 기존 메시지에 구독 설정 버튼 추가
-    if (alertMessage.blocks) {
-      alertMessage.blocks.push({ type: 'divider' });
-      alertMessage.blocks.push(subscriptionBlock);
-    } else if (alertMessage.attachments) {
+    if (alertMessage.blocks && Array.isArray(alertMessage.blocks)) {
+      (alertMessage.blocks as unknown[]).push({ type: 'divider' });
+      (alertMessage.blocks as unknown[]).push(subscriptionBlock);
+    } else if (alertMessage.attachments && Array.isArray(alertMessage.attachments)) {
       // Legacy attachment 방식
-      alertMessage.attachments.push({
+      (alertMessage.attachments as unknown[]).push({
         color: 'good',
         blocks: [subscriptionBlock]
       });

--- a/src/services/subscriptions/WebSubscriptionInterface.ts
+++ b/src/services/subscriptions/WebSubscriptionInterface.ts
@@ -218,7 +218,7 @@ export class WebSubscriptionInterface implements IWebSubscriptionInterface {
   /**
    * 구독 통계 조회 (웹 대시보드용)
    */
-  async getSubscriptionStats(token: string): Promise<any> {
+  async getSubscriptionStats(token: string): Promise<Record<string, unknown> | null> {
     try {
       const tokenInfo = await this.tokenService.validateToken(token);
       if (!tokenInfo) {

--- a/src/services/subscriptions/interfaces.ts
+++ b/src/services/subscriptions/interfaces.ts
@@ -35,7 +35,7 @@ export interface SubscriptionCommandParams {
 export interface SubscriptionCommandResult {
   success: boolean;
   message: string;
-  data?: any;
+  data?: Record<string, unknown>;
   error?: string;
 }
 
@@ -99,7 +99,7 @@ export interface WebSubscriptionInterface {
   /**
    * 구독 통계 조회
    */
-  getSubscriptionStats(token: string): Promise<any>;
+  getSubscriptionStats(token: string): Promise<Record<string, unknown> | null>;
 }
 
 /**
@@ -129,17 +129,17 @@ export interface InteractiveMessageInterface {
   /**
    * 구독 설정용 인터랙티브 메시지 생성
    */
-  createSubscriptionMessage(userId: string, currentSettings?: UserSubscription): any;
-  
+  createSubscriptionMessage(userId: string, currentSettings?: UserSubscription): Promise<Record<string, unknown>> | Record<string, unknown>;
+
   /**
    * 버튼 클릭 이벤트 처리
    */
-  handleButtonAction(payload: any): Promise<SubscriptionCommandResult>;
-  
+  handleButtonAction(payload: Record<string, unknown>): Promise<SubscriptionCommandResult>;
+
   /**
    * 설정 변경 확인 메시지
    */
-  createConfirmationMessage(result: SubscriptionCommandResult): any;
+  createConfirmationMessage(result: SubscriptionCommandResult): Record<string, unknown>;
 }
 
 /**
@@ -204,7 +204,7 @@ export interface HybridSubscriptionManager {
   /**
    * 플랫폼별 구독 통계
    */
-  getPlatformStats(): Promise<Record<string, any>>;
+  getPlatformStats(): Promise<Record<string, unknown>>;
 }
 
 /**

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -1,4 +1,5 @@
 import { WeatherAlert, WeatherApiParams, WeatherWarningType, WeatherRegion, AlertChange, WeatherForecast } from '../types/weather';
+import { WeatherApiResponse } from '../types/api';
 import { logger } from '../utils/logger';
 import { AlertCache } from './AlertCache';
 import * as fs from 'fs';
@@ -1542,7 +1543,7 @@ export class WeatherService {
   /**
    * JSON 응답 데이터를 WeatherForecast 객체로 파싱
    */
-  private parseForecastData(jsonData: any, regionId: string, regionName: string): WeatherForecast | null {
+  private parseForecastData(jsonData: WeatherApiResponse, regionId: string, regionName: string): WeatherForecast | null {
     try {
       // API 응답 검증
       if (!jsonData || !jsonData.response) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,110 @@
+/**
+ * 기상청 API 응답 타입 정의
+ */
+
+/**
+ * 기상청 API 공통 응답 래퍼
+ */
+export interface WeatherApiResponse {
+  response: {
+    header: {
+      resultCode: string;
+      resultMsg: string;
+    };
+    body?: {
+      dataType?: string;
+      items?: {
+        item: ForecastItem[];
+      };
+      numOfRows?: number;
+      pageNo?: number;
+      totalCount?: number;
+    };
+  };
+}
+
+/**
+ * 단기/초단기 예보 아이템
+ */
+export interface ForecastItem {
+  baseDate: string;
+  baseTime: string;
+  category: string;
+  fcstDate: string;
+  fcstTime: string;
+  fcstValue: string;
+  nx: number;
+  ny: number;
+}
+
+/**
+ * Slack Webhook 메시지 Attachment
+ */
+export interface SlackAttachment {
+  color: string;
+  title?: string;
+  text?: string;
+  fields: SlackAttachmentField[];
+  footer?: string;
+  ts?: number;
+  mrkdwn_in?: string[];
+}
+
+/**
+ * Slack Attachment 필드
+ */
+export interface SlackAttachmentField {
+  title: string;
+  value: string;
+  short: boolean;
+}
+
+/**
+ * Slack Webhook 페이로드
+ */
+export interface SlackPayload {
+  text: string;
+  attachments?: SlackAttachment[];
+}
+
+/**
+ * 특보 조회 필터
+ */
+export interface AlertFilters {
+  regionId?: string;
+  warningType?: string;
+  warningLevel?: string;
+  upperRegion?: string;
+}
+
+/**
+ * 특보 이력 조회 필터
+ */
+import { AlertChangeType } from './weather';
+
+export interface AlertHistoryFilters {
+  startDate: Date;
+  endDate: Date;
+  regionId?: string;
+  warningType?: string;
+  changeType?: AlertChangeType;
+}
+
+/**
+ * 변동 유형별 설정
+ */
+export interface ChangeTypeConfig {
+  emoji: string;
+  color: string;
+  text?: string;
+}
+
+/**
+ * 구독 통계 데이터
+ */
+export interface SubscriptionStats {
+  totalSubscriptions: number;
+  activeSubscriptions: number;
+  platformBreakdown: Record<string, number>;
+  regionBreakdown: Record<string, number>;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
 class Logger {
-  private formatMessage(level: string, message: string, ...args: any[]): string {
+  private formatMessage(level: string, message: string, ...args: unknown[]): string {
     const timestamp = new Date().toISOString();
     const formattedArgs = args.length > 0 ? ' ' + args.map(arg => {
       if (arg instanceof Error) {
@@ -11,19 +11,19 @@ class Logger {
     return `[${timestamp}] ${level.toUpperCase()}: ${message}${formattedArgs}`;
   }
 
-  info(message: string, ...args: any[]): void {
+  info(message: string, ...args: unknown[]): void {
     console.log(this.formatMessage('info', message, ...args));
   }
 
-  error(message: string, ...args: any[]): void {
+  error(message: string, ...args: unknown[]): void {
     console.error(this.formatMessage('error', message, ...args));
   }
 
-  warn(message: string, ...args: any[]): void {
+  warn(message: string, ...args: unknown[]): void {
     console.warn(this.formatMessage('warn', message, ...args));
   }
 
-  debug(message: string, ...args: any[]): void {
+  debug(message: string, ...args: unknown[]): void {
     if (process.env.NODE_ENV === 'development' || process.env.DEBUG === 'true') {
       console.debug(this.formatMessage('debug', message, ...args));
     }


### PR DESCRIPTION
## Summary
- `src/types/api.ts` 신규 생성: WeatherApiResponse, SlackAttachment, AlertFilters 등 공통 타입 정의
- 소스 코드 `any` 사용 **43개 → 1개**로 감소 (라이브러리 호환성 1건만 잔존)
- npm 취약점: `qs` overrides 추가로 high 2개 해결 (moderate 4개는 `request` 라이브러리 근본 문제로 #95에서 대응)

## 주요 변경 파일 (20개)
- `src/types/api.ts` (신규) - 공통 API 타입 정의
- `src/utils/logger.ts` - `any[]` → `unknown[]`
- `src/routes/alertRoutes.ts` - `any` → `AlertFilters`, `AlertChangeType`
- `src/services/notifications/SlackNotificationService.ts` - `any` → `SlackAttachment`, `SlackPayload`
- `src/services/weatherService.ts` - `any` → `WeatherApiResponse`
- `src/services/DatabaseService.ts` - `any` → 타입 안전한 groupBy 필드
- `src/services/notifications/interfaces.ts` - `any` → `Record<string, unknown>`
- `src/services/subscriptions/interfaces.ts` - `any` → 구체적 타입
- 그 외 8개 서비스 파일

## Related Issue
Closes #117 (Epic: #115)

## Test plan
- [x] `npm run build` 성공 (0 errors)
- [x] `npm test` 361개 테스트 전부 통과
- [x] `npm audit` high 0개 (moderate 4개는 #95에서 근본 해결 예정)
- [x] 소스 코드 `any` 사용 1개만 잔존 (라이브러리 호환성)