### PR TITLE
test: 테스트 커버리지 85% 달성 - Phase D (#119)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,9 @@ module.exports = {
     'src/**/*.ts',
     '!src/**/*.d.ts',
     '!src/index.ts', // 메인 진입점 제외
+    '!src/server.ts', // Express 서버 부트스트랩 (통합 테스트 대상)
+    '!src/examples/**', // 데모 스크립트
+    '!src/**/index.ts', // Barrel export 파일
   ],
   
   // 모듈 해석

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,8 @@ module.exports = {
     '!src/index.ts', // 메인 진입점 제외
     '!src/server.ts', // Express 서버 부트스트랩 (통합 테스트 대상)
     '!src/examples/**', // 데모 스크립트
-    '!src/**/index.ts', // Barrel export 파일
+    '!src/services/notifications/index.ts', // Barrel export
+    '!src/services/subscriptions/index.ts', // Barrel export
   ],
   
   // 모듈 해석

--- a/src/__tests__/routes/subscriptionRoutes.test.ts
+++ b/src/__tests__/routes/subscriptionRoutes.test.ts
@@ -1,0 +1,396 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import subscriptionRouter, { initializeSubscriptionRoutes } from '../../routes/subscriptionRoutes';
+import { WebSubscriptionInterface } from '../../services/subscriptions/WebSubscriptionInterface';
+import { SubscriptionManager } from '../../services/notifications/SubscriptionManager';
+import { TokenService } from '../../services/TokenService';
+
+// Mock dependencies
+jest.mock('../../services/subscriptions/WebSubscriptionInterface');
+jest.mock('../../services/notifications/SubscriptionManager');
+jest.mock('../../services/TokenService');
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+describe('Subscription Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/subscriptions', subscriptionRouter);
+  });
+
+  describe('초기화 전 요청', () => {
+    it('WebSubscriptionInterface 미초기화 시 500을 반환한다', async () => {
+      const res = await request(app).post('/api/subscriptions/auth').send({ token: 'test' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Service not initialized');
+    });
+  });
+
+  describe('초기화 후 요청', () => {
+    let mockWebInterface: any;
+
+    beforeAll(() => {
+      // WebSubscriptionInterface mock 설정
+      const mockSubscriptionManager = new SubscriptionManager() as any;
+      const mockTokenService = new TokenService(null as any) as any;
+
+      initializeSubscriptionRoutes(mockSubscriptionManager, mockTokenService);
+
+      // WebSubscriptionInterface의 프로토타입 메서드를 mock
+      mockWebInterface = (WebSubscriptionInterface as jest.Mock).mock.instances[0];
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('POST /api/subscriptions/auth', () => {
+      it('유효한 토큰으로 인증에 성공한다', async () => {
+        const mockSubscription = {
+          platform: 'web',
+          userId: 'user1',
+          targetRegions: ['L1100000'],
+          enabled: true,
+        };
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue(mockSubscription);
+
+        const res = await request(app)
+          .post('/api/subscriptions/auth')
+          .send({ token: 'valid-token' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+      });
+
+      it('토큰이 없으면 400을 반환한다', async () => {
+        const res = await request(app)
+          .post('/api/subscriptions/auth')
+          .send({});
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('Missing or invalid token');
+      });
+
+      it('토큰이 문자열이 아니면 400을 반환한다', async () => {
+        const res = await request(app)
+          .post('/api/subscriptions/auth')
+          .send({ token: 123 });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('유효하지 않은 토큰이면 401을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue(null);
+
+        const res = await request(app)
+          .post('/api/subscriptions/auth')
+          .send({ token: 'invalid-token' });
+
+        expect(res.status).toBe(401);
+        expect(res.body.error).toBe('Invalid or expired token');
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockRejectedValue(new Error('Internal'));
+
+        const res = await request(app)
+          .post('/api/subscriptions/auth')
+          .send({ token: 'some-token' });
+
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe('Internal server error');
+      });
+    });
+
+    describe('GET /api/subscriptions/me', () => {
+      it('인증된 사용자의 구독 정보를 반환한다', async () => {
+        const mockSub = { platform: 'web', userId: 'u1' };
+        const mockEnhanced = { success: true, data: { ...mockSub, regionNames: ['서울'] } };
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue(mockSub);
+        mockWebInterface.getEnhancedSubscriptionInfo = jest.fn().mockResolvedValue(mockEnhanced);
+
+        const res = await request(app)
+          .get('/api/subscriptions/me')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+      });
+
+      it('토큰이 없으면 401을 반환한다', async () => {
+        const res = await request(app).get('/api/subscriptions/me');
+
+        expect(res.status).toBe(401);
+        expect(res.body.error).toBe('Missing authorization token');
+      });
+
+      it('유효하지 않은 토큰이면 401을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue(null);
+
+        const res = await request(app)
+          .get('/api/subscriptions/me')
+          .set('Authorization', 'Bearer bad-token');
+
+        expect(res.status).toBe(401);
+      });
+
+      it('확장 정보 조회 실패 시 404를 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.getEnhancedSubscriptionInfo = jest.fn().mockResolvedValue({
+          success: false,
+          error: 'Not found',
+        });
+
+        const res = await request(app)
+          .get('/api/subscriptions/me')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(404);
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockRejectedValue(new Error('err'));
+
+        const res = await request(app)
+          .get('/api/subscriptions/me')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(500);
+      });
+    });
+
+    describe('PUT /api/subscriptions/update', () => {
+      it('구독 설정을 업데이트한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.updateSubscription = jest.fn().mockResolvedValue({ success: true });
+
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .set('Authorization', 'Bearer valid-token')
+          .send({
+            targetRegions: ['L1100000'],
+            warningTypes: ['W'],
+            enabled: true,
+          });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+      });
+
+      it('토큰이 없으면 401을 반환한다', async () => {
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .send({ enabled: true });
+
+        expect(res.status).toBe(401);
+      });
+
+      it('targetRegions가 배열이 아니면 400을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .set('Authorization', 'Bearer valid-token')
+          .send({ targetRegions: 'not-array' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('targetRegions must be an array');
+      });
+
+      it('warningTypes가 배열이 아니면 400을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .set('Authorization', 'Bearer valid-token')
+          .send({ warningTypes: 'not-array' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('warningTypes must be an array');
+      });
+
+      it('enabled가 boolean이 아니면 400을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .set('Authorization', 'Bearer valid-token')
+          .send({ enabled: 'yes' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('enabled must be a boolean');
+      });
+
+      it('업데이트 실패 시 400을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.updateSubscription = jest.fn().mockResolvedValue({
+          success: false,
+          error: 'Update failed',
+        });
+
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .set('Authorization', 'Bearer valid-token')
+          .send({ enabled: false });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.updateSubscription = jest.fn().mockRejectedValue(new Error('err'));
+
+        const res = await request(app)
+          .put('/api/subscriptions/update')
+          .set('Authorization', 'Bearer valid-token')
+          .send({ enabled: true });
+
+        expect(res.status).toBe(500);
+      });
+    });
+
+    describe('DELETE /api/subscriptions/delete', () => {
+      it('구독을 삭제한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.deleteSubscription = jest.fn().mockResolvedValue({ success: true });
+
+        const res = await request(app)
+          .delete('/api/subscriptions/delete')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+      });
+
+      it('토큰이 없으면 401을 반환한다', async () => {
+        const res = await request(app).delete('/api/subscriptions/delete');
+
+        expect(res.status).toBe(401);
+      });
+
+      it('삭제 실패 시 400을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.deleteSubscription = jest.fn().mockResolvedValue({
+          success: false,
+          error: 'Delete failed',
+        });
+
+        const res = await request(app)
+          .delete('/api/subscriptions/delete')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(400);
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.deleteSubscription = jest.fn().mockRejectedValue(new Error('err'));
+
+        const res = await request(app)
+          .delete('/api/subscriptions/delete')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(500);
+      });
+    });
+
+    describe('GET /api/subscriptions/stats', () => {
+      it('구독 통계를 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.getSubscriptionStats = jest.fn().mockResolvedValue({ total: 10 });
+
+        const res = await request(app)
+          .get('/api/subscriptions/stats')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.total).toBe(10);
+      });
+
+      it('토큰이 없으면 401을 반환한다', async () => {
+        const res = await request(app).get('/api/subscriptions/stats');
+
+        expect(res.status).toBe(401);
+      });
+
+      it('통계 조회 실패 시 401을 반환한다', async () => {
+        mockWebInterface.authenticateWithToken = jest.fn().mockResolvedValue({ userId: 'u1' });
+        mockWebInterface.getSubscriptionStats = jest.fn().mockResolvedValue(null);
+
+        const res = await request(app)
+          .get('/api/subscriptions/stats')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(401);
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.getSubscriptionStats = jest.fn().mockRejectedValue(new Error('err'));
+
+        const res = await request(app)
+          .get('/api/subscriptions/stats')
+          .set('Authorization', 'Bearer valid-token');
+
+        expect(res.status).toBe(500);
+      });
+    });
+
+    describe('GET /api/subscriptions/regions', () => {
+      it('사용 가능한 지역 목록을 반환한다', async () => {
+        mockWebInterface.getAvailableRegions = jest.fn().mockReturnValue([
+          { id: 'L1100000', name: '서울특별시' },
+        ]);
+
+        const res = await request(app).get('/api/subscriptions/regions');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data).toHaveLength(1);
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.getAvailableRegions = jest.fn().mockImplementation(() => {
+          throw new Error('Region error');
+        });
+
+        const res = await request(app).get('/api/subscriptions/regions');
+
+        expect(res.status).toBe(500);
+      });
+    });
+
+    describe('GET /api/subscriptions/warning-types', () => {
+      it('사용 가능한 특보 종류 목록을 반환한다', async () => {
+        mockWebInterface.getAvailableWarningTypes = jest.fn().mockReturnValue([
+          { code: 'W', name: '강풍' },
+        ]);
+
+        const res = await request(app).get('/api/subscriptions/warning-types');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data).toHaveLength(1);
+      });
+
+      it('내부 오류 시 500을 반환한다', async () => {
+        mockWebInterface.getAvailableWarningTypes = jest.fn().mockImplementation(() => {
+          throw new Error('Type error');
+        });
+
+        const res = await request(app).get('/api/subscriptions/warning-types');
+
+        expect(res.status).toBe(500);
+      });
+    });
+  });
+});

--- a/src/__tests__/services/DatabaseService.test.ts
+++ b/src/__tests__/services/DatabaseService.test.ts
@@ -1,0 +1,574 @@
+import { AlertChangeType, CachedAlert } from '../../types/weather';
+
+// Mock logger - must be before DatabaseService import
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+// Mock PrismaClient - jest.mock is hoisted, so use inline object
+const mockPrisma = {
+  $connect: jest.fn(),
+  $disconnect: jest.fn(),
+  weatherAlert: {
+    upsert: jest.fn(),
+    findMany: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  alertHistory: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    groupBy: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+  regionMapping: {
+    upsert: jest.fn(),
+    findUnique: jest.fn(),
+  },
+};
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => mockPrisma),
+  };
+});
+
+import { DatabaseService } from '../../services/DatabaseService';
+
+describe('DatabaseService', () => {
+  let dbService: DatabaseService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // 싱글톤 인스턴스 리셋
+    (DatabaseService as any).instance = undefined;
+    dbService = new DatabaseService();
+  });
+
+  describe('getInstance', () => {
+    it('싱글톤 인스턴스를 반환한다', () => {
+      const instance1 = DatabaseService.getInstance();
+      const instance2 = DatabaseService.getInstance();
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('getPrismaClient', () => {
+    it('Prisma 클라이언트를 반환한다', () => {
+      const client = dbService.getPrismaClient();
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('connect', () => {
+    it('데이터베이스에 성공적으로 연결한다', async () => {
+      mockPrisma.$connect.mockResolvedValue(undefined);
+
+      await dbService.connect();
+
+      expect(mockPrisma.$connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('연결 실패 시 예외를 던진다', async () => {
+      mockPrisma.$connect.mockRejectedValue(new Error('Connection failed'));
+
+      await expect(dbService.connect()).rejects.toThrow('Connection failed');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('데이터베이스 연결을 종료한다', async () => {
+      mockPrisma.$disconnect.mockResolvedValue(undefined);
+
+      await dbService.disconnect();
+
+      expect(mockPrisma.$disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('연결 종료 실패 시 예외를 던진다', async () => {
+      mockPrisma.$disconnect.mockRejectedValue(new Error('Disconnect failed'));
+
+      await expect(dbService.disconnect()).rejects.toThrow('Disconnect failed');
+    });
+  });
+
+  describe('saveWeatherAlert', () => {
+    const mockAlert = {
+      REG_ID: 'L1100000',
+      REG_NAME: '서울특별시',
+      upperRegion: '서울특별시',
+      WRN: 'W',
+      LVL: '주의보',
+      CMD: '1',
+      TM_FC: '202602261000',
+      TM_EF: '202602261200',
+      TM_ED: '',
+      other: 'value',
+    } as any;
+
+    it('특보를 성공적으로 저장한다', async () => {
+      mockPrisma.weatherAlert.upsert.mockResolvedValue({});
+
+      await dbService.saveWeatherAlert(mockAlert);
+
+      expect(mockPrisma.weatherAlert.upsert).toHaveBeenCalledTimes(1);
+      const call = mockPrisma.weatherAlert.upsert.mock.calls[0][0];
+      expect(call.where.regionId_warningType.regionId).toBe('L1100000');
+      expect(call.where.regionId_warningType.warningType).toBe('W');
+    });
+
+    it('저장 실패 시 예외를 던진다', async () => {
+      mockPrisma.weatherAlert.upsert.mockRejectedValue(new Error('Save failed'));
+
+      await expect(dbService.saveWeatherAlert(mockAlert)).rejects.toThrow('Save failed');
+    });
+  });
+
+  describe('saveAlertHistory', () => {
+    it('특보 변동 이력을 저장한다', async () => {
+      mockPrisma.alertHistory.create.mockResolvedValue({});
+      const change = {
+        type: 'NEW' as AlertChangeType,
+        current: {
+          regionId: 'L1100000',
+          regionName: '서울특별시',
+          upperRegion: '서울특별시',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+        },
+        previous: undefined,
+      };
+
+      await dbService.saveAlertHistory(change as any);
+
+      expect(mockPrisma.alertHistory.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('RESOLVED 타입에서 previous 데이터를 사용한다', async () => {
+      mockPrisma.alertHistory.create.mockResolvedValue({});
+      const change = {
+        type: 'RESOLVED' as AlertChangeType,
+        current: undefined,
+        previous: {
+          regionId: 'L1100000',
+          regionName: '서울특별시',
+          upperRegion: '서울특별시',
+          warningType: 'W',
+          level: '주의보',
+          command: '3',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+        },
+      };
+
+      await dbService.saveAlertHistory(change as any);
+
+      expect(mockPrisma.alertHistory.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('필수 필드 누락 시 예외를 던진다', async () => {
+      const change = {
+        type: 'NEW' as AlertChangeType,
+        current: {
+          regionId: '',
+          regionName: '',
+          warningType: '',
+          level: '',
+          command: '1',
+        },
+        previous: undefined,
+      };
+
+      await expect(dbService.saveAlertHistory(change as any)).rejects.toThrow('필수 필드 누락');
+    });
+
+    it('DB 오류 시 예외를 던진다', async () => {
+      mockPrisma.alertHistory.create.mockRejectedValue(new Error('DB error'));
+      const change = {
+        type: 'NEW' as AlertChangeType,
+        current: {
+          regionId: 'L1100000',
+          regionName: '서울',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+        },
+      };
+
+      await expect(dbService.saveAlertHistory(change as any)).rejects.toThrow('DB error');
+    });
+  });
+
+  describe('saveWeatherAlerts', () => {
+    it('여러 특보를 일괄 저장한다', async () => {
+      mockPrisma.weatherAlert.upsert.mockResolvedValue({});
+
+      const alerts = [
+        { REG_ID: 'L1100000', REG_NAME: '서울', WRN: 'W', LVL: '주의보', CMD: '1', TM_FC: '202602261000', TM_EF: '202602261200' },
+        { REG_ID: 'L2600000', REG_NAME: '부산', WRN: 'R', LVL: '경보', CMD: '1', TM_FC: '202602261000', TM_EF: '202602261200' },
+      ] as any[];
+
+      await dbService.saveWeatherAlerts(alerts);
+
+      expect(mockPrisma.weatherAlert.upsert).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('saveAlertHistories', () => {
+    it('여러 이력을 일괄 저장한다', async () => {
+      mockPrisma.alertHistory.create.mockResolvedValue({});
+
+      const changes = [
+        {
+          type: 'NEW' as AlertChangeType,
+          current: { regionId: 'L1100000', regionName: '서울', warningType: 'W', level: '주의보', command: '1', announcedAt: '202602261000', effectiveAt: '202602261200' },
+        },
+      ];
+
+      await dbService.saveAlertHistories(changes as any);
+
+      expect(mockPrisma.alertHistory.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCurrentAlerts', () => {
+    it('현재 발효 중인 특보를 조회한다', async () => {
+      const mockAlerts = [
+        { id: 1, regionId: 'L1100000', regionName: '서울', warningType: 'W' },
+      ];
+      mockPrisma.weatherAlert.findMany.mockResolvedValue(mockAlerts);
+
+      const result = await dbService.getCurrentAlerts();
+
+      expect(result).toHaveLength(1);
+      expect(mockPrisma.weatherAlert.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('필터를 적용하여 조회한다', async () => {
+      mockPrisma.weatherAlert.findMany.mockResolvedValue([]);
+
+      await dbService.getCurrentAlerts({
+        regionId: 'L1100000',
+        warningType: 'W',
+        warningLevel: '주의보',
+        upperRegion: '서울특별시',
+      });
+
+      const call = mockPrisma.weatherAlert.findMany.mock.calls[0][0];
+      expect(call.where.regionId).toBe('L1100000');
+      expect(call.where.warningType).toBe('W');
+    });
+
+    it('DB 오류 시 예외를 던진다', async () => {
+      mockPrisma.weatherAlert.findMany.mockRejectedValue(new Error('Query failed'));
+
+      await expect(dbService.getCurrentAlerts()).rejects.toThrow('Query failed');
+    });
+  });
+
+  describe('getAlertHistory', () => {
+    it('기간별 특보 이력을 조회한다', async () => {
+      mockPrisma.alertHistory.findMany.mockResolvedValue([{ id: 1 }]);
+
+      const result = await dbService.getAlertHistory({
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-02-26'),
+      });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('모든 필터를 적용한다', async () => {
+      mockPrisma.alertHistory.findMany.mockResolvedValue([]);
+
+      await dbService.getAlertHistory({
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-02-26'),
+        regionId: 'L1100000',
+        warningType: 'W',
+        changeType: 'NEW' as AlertChangeType,
+      });
+
+      const call = mockPrisma.alertHistory.findMany.mock.calls[0][0];
+      expect(call.where.regionId).toBe('L1100000');
+      expect(call.where.changeType).toBe('NEW');
+    });
+
+    it('DB 오류 시 예외를 던진다', async () => {
+      mockPrisma.alertHistory.findMany.mockRejectedValue(new Error('Query error'));
+
+      await expect(
+        dbService.getAlertHistory({
+          startDate: new Date(),
+          endDate: new Date(),
+        })
+      ).rejects.toThrow('Query error');
+    });
+  });
+
+  describe('getAlertStatistics', () => {
+    it('지역별 통계를 조회한다', async () => {
+      mockPrisma.alertHistory.groupBy.mockResolvedValue([
+        { upperRegion: '서울특별시', _count: { id: 10 } },
+      ]);
+
+      const result = await dbService.getAlertStatistics({
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-02-26'),
+        groupBy: 'region',
+      });
+
+      expect(result).toHaveLength(1);
+      const call = mockPrisma.alertHistory.groupBy.mock.calls[0][0];
+      expect(call.by).toEqual(['upperRegion']);
+    });
+
+    it('특보종류별 통계를 조회한다', async () => {
+      mockPrisma.alertHistory.groupBy.mockResolvedValue([]);
+
+      await dbService.getAlertStatistics({
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-02-26'),
+        groupBy: 'warningType',
+      });
+
+      const call = mockPrisma.alertHistory.groupBy.mock.calls[0][0];
+      expect(call.by).toEqual(['warningType']);
+    });
+
+    it('수준별 통계를 조회한다', async () => {
+      mockPrisma.alertHistory.groupBy.mockResolvedValue([]);
+
+      await dbService.getAlertStatistics({
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-02-26'),
+        groupBy: 'level',
+      });
+
+      const call = mockPrisma.alertHistory.groupBy.mock.calls[0][0];
+      expect(call.by).toEqual(['warningLevel']);
+    });
+
+    it('DB 오류 시 예외를 던진다', async () => {
+      mockPrisma.alertHistory.groupBy.mockRejectedValue(new Error('Stats error'));
+
+      await expect(
+        dbService.getAlertStatistics({
+          startDate: new Date(),
+          endDate: new Date(),
+          groupBy: 'region',
+        })
+      ).rejects.toThrow('Stats error');
+    });
+  });
+
+  describe('cleanupOldData', () => {
+    it('기본 365일 이전 데이터를 삭제한다', async () => {
+      mockPrisma.alertHistory.deleteMany.mockResolvedValue({ count: 100 });
+
+      const result = await dbService.cleanupOldData();
+
+      expect(result).toBe(100);
+    });
+
+    it('지정된 보관 기간으로 삭제한다', async () => {
+      mockPrisma.alertHistory.deleteMany.mockResolvedValue({ count: 50 });
+
+      const result = await dbService.cleanupOldData(30);
+
+      expect(result).toBe(50);
+    });
+
+    it('DB 오류 시 예외를 던진다', async () => {
+      mockPrisma.alertHistory.deleteMany.mockRejectedValue(new Error('Cleanup error'));
+
+      await expect(dbService.cleanupOldData()).rejects.toThrow('Cleanup error');
+    });
+  });
+
+  describe('syncCachedAlerts', () => {
+    it('캐시된 특보 데이터를 동기화한다', async () => {
+      mockPrisma.weatherAlert.upsert.mockResolvedValue({});
+      mockPrisma.weatherAlert.updateMany.mockResolvedValue({ count: 2 });
+
+      const cachedAlerts: CachedAlert[] = [
+        {
+          key: 'L1100000-W-주의보-1',
+          regionId: 'L1100000',
+          regionName: '서울특별시',
+          upperRegion: '서울특별시',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+          lastUpdated: new Date().toISOString(),
+        },
+      ];
+
+      await dbService.syncCachedAlerts(cachedAlerts);
+
+      expect(mockPrisma.weatherAlert.upsert).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.weatherAlert.updateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('빈 캐시일 때 모든 특보를 해제한다', async () => {
+      mockPrisma.weatherAlert.updateMany.mockResolvedValue({ count: 3 });
+
+      await dbService.syncCachedAlerts([]);
+
+      expect(mockPrisma.weatherAlert.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.weatherAlert.updateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('endTime이 있는 캐시 데이터를 처리한다', async () => {
+      mockPrisma.weatherAlert.upsert.mockResolvedValue({});
+      mockPrisma.weatherAlert.updateMany.mockResolvedValue({ count: 0 });
+
+      const cachedAlerts: CachedAlert[] = [
+        {
+          key: 'L1100000-W-주의보-1',
+          regionId: 'L1100000',
+          regionName: '서울특별시',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+          endTime: '202602271000',
+          lastUpdated: new Date().toISOString(),
+        },
+      ];
+
+      await dbService.syncCachedAlerts(cachedAlerts);
+
+      expect(mockPrisma.weatherAlert.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('동기화 실패 시 예외를 던진다', async () => {
+      mockPrisma.weatherAlert.upsert.mockRejectedValue(new Error('Sync failed'));
+
+      const cachedAlerts: CachedAlert[] = [
+        {
+          key: 'L1100000-W-주의보-1',
+          regionId: 'L1100000',
+          regionName: '서울',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+          lastUpdated: new Date().toISOString(),
+        },
+      ];
+
+      await expect(dbService.syncCachedAlerts(cachedAlerts)).rejects.toThrow('Sync failed');
+    });
+  });
+
+  describe('parseKmaTimestamp (private)', () => {
+    it('유효한 KMA 타임스탬프를 변환한다', async () => {
+      // syncCachedAlerts를 통해 간접 테스트
+      mockPrisma.weatherAlert.upsert.mockResolvedValue({});
+      mockPrisma.weatherAlert.updateMany.mockResolvedValue({ count: 0 });
+
+      const cachedAlerts: CachedAlert[] = [
+        {
+          key: 'L1100000-W-주의보-1',
+          regionId: 'L1100000',
+          regionName: '서울',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: '202602261000',
+          effectiveAt: '202602261200',
+          lastUpdated: new Date().toISOString(),
+        },
+      ];
+
+      await dbService.syncCachedAlerts(cachedAlerts);
+
+      const upsertCall = mockPrisma.weatherAlert.upsert.mock.calls[0][0];
+      expect(upsertCall.create.announcedAt).toBeInstanceOf(Date);
+      expect(upsertCall.create.effectiveAt).toBeInstanceOf(Date);
+    });
+
+    it('잘못된 형식의 타임스탬프는 예외를 던진다', async () => {
+      mockPrisma.weatherAlert.upsert.mockResolvedValue({});
+
+      const cachedAlerts: CachedAlert[] = [
+        {
+          key: 'L1100000-W-주의보-1',
+          regionId: 'L1100000',
+          regionName: '서울',
+          warningType: 'W',
+          level: '주의보',
+          command: '1',
+          announcedAt: 'invalid',
+          effectiveAt: '202602261200',
+          lastUpdated: new Date().toISOString(),
+        },
+      ];
+
+      await expect(dbService.syncCachedAlerts(cachedAlerts)).rejects.toThrow('Invalid KMA timestamp');
+    });
+  });
+
+  describe('saveRegionMapping', () => {
+    it('지역 매핑을 저장한다', async () => {
+      mockPrisma.regionMapping.upsert.mockResolvedValue({});
+
+      await dbService.saveRegionMapping('L1100000', '서울특별시', '서울특별시');
+
+      expect(mockPrisma.regionMapping.upsert).toHaveBeenCalledTimes(1);
+      const call = mockPrisma.regionMapping.upsert.mock.calls[0][0];
+      expect(call.where.regionId).toBe('L1100000');
+    });
+
+    it('저장 실패 시 예외를 던진다', async () => {
+      mockPrisma.regionMapping.upsert.mockRejectedValue(new Error('Mapping error'));
+
+      await expect(
+        dbService.saveRegionMapping('L1100000', '서울', '서울특별시')
+      ).rejects.toThrow('Mapping error');
+    });
+  });
+
+  describe('getRegionMapping', () => {
+    it('지역 매핑을 조회한다', async () => {
+      mockPrisma.regionMapping.findUnique.mockResolvedValue({
+        regionId: 'L1100000',
+        regionName: '서울특별시',
+        upperRegion: '서울특별시',
+      });
+
+      const result = await dbService.getRegionMapping('L1100000');
+
+      expect(result).not.toBeNull();
+      expect(result.regionName).toBe('서울특별시');
+    });
+
+    it('존재하지 않는 매핑은 null을 반환한다', async () => {
+      mockPrisma.regionMapping.findUnique.mockResolvedValue(null);
+
+      const result = await dbService.getRegionMapping('L9999999');
+
+      expect(result).toBeNull();
+    });
+
+    it('조회 실패 시 예외를 던진다', async () => {
+      mockPrisma.regionMapping.findUnique.mockRejectedValue(new Error('Query error'));
+
+      await expect(dbService.getRegionMapping('L1100000')).rejects.toThrow('Query error');
+    });
+  });
+});

--- a/src/__tests__/services/TokenService.test.ts
+++ b/src/__tests__/services/TokenService.test.ts
@@ -1,4 +1,4 @@
-import { TokenService, TokenInfo, TokenGenerationOptions } from '../../services/TokenService';
+import { TokenService } from '../../services/TokenService';
 
 // Mock Prisma
 const mockPrisma = {

--- a/src/__tests__/services/TokenService.test.ts
+++ b/src/__tests__/services/TokenService.test.ts
@@ -1,0 +1,300 @@
+import { TokenService, TokenInfo, TokenGenerationOptions } from '../../services/TokenService';
+
+// Mock Prisma
+const mockPrisma = {
+  webAccessToken: {
+    upsert: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    deleteMany: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+// Mock logger
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+describe('TokenService', () => {
+  let tokenService: TokenService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tokenService = new TokenService(mockPrisma as any);
+  });
+
+  describe('generateToken', () => {
+    it('새 토큰을 생성한다', async () => {
+      const mockRecord = {
+        token: 'abc123',
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: 'Test User',
+        expiresAt: new Date('2026-03-28'),
+        createdAt: new Date('2026-02-26'),
+      };
+      mockPrisma.webAccessToken.upsert.mockResolvedValue(mockRecord);
+
+      const result = await tokenService.generateToken({
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: 'Test User',
+      });
+
+      expect(result.platform).toBe('telegram');
+      expect(result.userId).toBe('user1');
+      expect(result.displayName).toBe('Test User');
+      expect(mockPrisma.webAccessToken.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('expiresInHours 옵션을 사용한다', async () => {
+      const mockRecord = {
+        token: 'abc123',
+        platform: 'slack',
+        userId: 'u2',
+        displayName: null,
+        expiresAt: new Date('2026-02-27'),
+        createdAt: new Date('2026-02-26'),
+      };
+      mockPrisma.webAccessToken.upsert.mockResolvedValue(mockRecord);
+
+      const result = await tokenService.generateToken({
+        platform: 'slack',
+        userId: 'u2',
+        expiresInHours: 24,
+      });
+
+      expect(result.displayName).toBeUndefined();
+      expect(result.platform).toBe('slack');
+    });
+
+    it('DB 오류 시 예외를 던진다', async () => {
+      mockPrisma.webAccessToken.upsert.mockRejectedValue(new Error('DB error'));
+
+      await expect(
+        tokenService.generateToken({
+          platform: 'telegram',
+          userId: 'user1',
+        })
+      ).rejects.toThrow('Failed to generate access token');
+    });
+  });
+
+  describe('validateToken', () => {
+    it('유효한 토큰의 정보를 반환한다', async () => {
+      const futureDate = new Date();
+      futureDate.setHours(futureDate.getHours() + 24);
+      const mockRecord = {
+        token: 'valid-token',
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: 'Test',
+        expiresAt: futureDate,
+        createdAt: new Date(),
+      };
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue(mockRecord);
+      mockPrisma.webAccessToken.update.mockResolvedValue(mockRecord);
+
+      const result = await tokenService.validateToken('valid-token');
+
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe('telegram');
+      expect(result!.userId).toBe('user1');
+    });
+
+    it('존재하지 않는 토큰은 null을 반환한다', async () => {
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue(null);
+
+      const result = await tokenService.validateToken('invalid-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('만료된 토큰은 null을 반환한다', async () => {
+      const pastDate = new Date();
+      pastDate.setHours(pastDate.getHours() - 24);
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue({
+        token: 'expired-token',
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: null,
+        expiresAt: pastDate,
+        createdAt: new Date(),
+      });
+
+      const result = await tokenService.validateToken('expired-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('DB 오류 시 null을 반환한다', async () => {
+      mockPrisma.webAccessToken.findUnique.mockRejectedValue(new Error('DB error'));
+
+      const result = await tokenService.validateToken('some-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('lastUsedAt 업데이트 실패해도 토큰 검증은 성공한다', async () => {
+      const futureDate = new Date();
+      futureDate.setHours(futureDate.getHours() + 24);
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue({
+        token: 'valid-token',
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: null,
+        expiresAt: futureDate,
+        createdAt: new Date(),
+      });
+      mockPrisma.webAccessToken.update.mockRejectedValue(new Error('update failed'));
+
+      const result = await tokenService.validateToken('valid-token');
+
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe('user1');
+    });
+  });
+
+  describe('getTokenByUser', () => {
+    it('사용자의 유효한 토큰을 반환한다', async () => {
+      const futureDate = new Date();
+      futureDate.setHours(futureDate.getHours() + 24);
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue({
+        token: 'user-token',
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: 'Test',
+        expiresAt: futureDate,
+        createdAt: new Date(),
+      });
+
+      const result = await tokenService.getTokenByUser('telegram', 'user1');
+
+      expect(result).not.toBeNull();
+      expect(result!.token).toBe('user-token');
+    });
+
+    it('토큰이 없으면 null을 반환한다', async () => {
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue(null);
+
+      const result = await tokenService.getTokenByUser('telegram', 'unknown');
+
+      expect(result).toBeNull();
+    });
+
+    it('만료된 토큰이면 null을 반환한다', async () => {
+      const pastDate = new Date();
+      pastDate.setHours(pastDate.getHours() - 24);
+      mockPrisma.webAccessToken.findUnique.mockResolvedValue({
+        token: 'expired',
+        platform: 'telegram',
+        userId: 'user1',
+        displayName: null,
+        expiresAt: pastDate,
+        createdAt: new Date(),
+      });
+
+      const result = await tokenService.getTokenByUser('telegram', 'user1');
+
+      expect(result).toBeNull();
+    });
+
+    it('DB 오류 시 null을 반환한다', async () => {
+      mockPrisma.webAccessToken.findUnique.mockRejectedValue(new Error('DB error'));
+
+      const result = await tokenService.getTokenByUser('telegram', 'user1');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('revokeToken', () => {
+    it('토큰을 성공적으로 삭제한다', async () => {
+      mockPrisma.webAccessToken.delete.mockResolvedValue({});
+
+      const result = await tokenService.revokeToken('token-to-revoke');
+
+      expect(result).toBe(true);
+      expect(mockPrisma.webAccessToken.delete).toHaveBeenCalledWith({
+        where: { token: 'token-to-revoke' },
+      });
+    });
+
+    it('삭제 실패 시 false를 반환한다', async () => {
+      mockPrisma.webAccessToken.delete.mockRejectedValue(new Error('Not found'));
+
+      const result = await tokenService.revokeToken('nonexistent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('cleanupExpiredTokens', () => {
+    it('만료된 토큰을 정리하고 개수를 반환한다', async () => {
+      mockPrisma.webAccessToken.deleteMany.mockResolvedValue({ count: 5 });
+
+      const result = await tokenService.cleanupExpiredTokens();
+
+      expect(result).toBe(5);
+      expect(mockPrisma.webAccessToken.deleteMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('만료된 토큰이 없으면 0을 반환한다', async () => {
+      mockPrisma.webAccessToken.deleteMany.mockResolvedValue({ count: 0 });
+
+      const result = await tokenService.cleanupExpiredTokens();
+
+      expect(result).toBe(0);
+    });
+
+    it('DB 오류 시 0을 반환한다', async () => {
+      mockPrisma.webAccessToken.deleteMany.mockRejectedValue(new Error('DB error'));
+
+      const result = await tokenService.cleanupExpiredTokens();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('getActiveTokenStats', () => {
+    it('플랫폼별 활성 토큰 통계를 반환한다', async () => {
+      mockPrisma.webAccessToken.findMany.mockResolvedValue([
+        { platform: 'telegram' },
+        { platform: 'telegram' },
+        { platform: 'slack' },
+        { platform: 'email' },
+      ]);
+
+      const result = await tokenService.getActiveTokenStats();
+
+      expect(result).toEqual({
+        telegram: 2,
+        slack: 1,
+        email: 1,
+      });
+    });
+
+    it('활성 토큰이 없으면 빈 객체를 반환한다', async () => {
+      mockPrisma.webAccessToken.findMany.mockResolvedValue([]);
+
+      const result = await tokenService.getActiveTokenStats();
+
+      expect(result).toEqual({});
+    });
+
+    it('DB 오류 시 빈 객체를 반환한다', async () => {
+      mockPrisma.webAccessToken.findMany.mockRejectedValue(new Error('DB error'));
+
+      const result = await tokenService.getActiveTokenStats();
+
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
+++ b/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
@@ -608,7 +608,8 @@ describe('MultiplatformNotificationService', () => {
       const svc = new MultiplatformNotificationService([failService]);
       const changes = [createMockChange('NEW'), createMockChange('RESOLVED')];
       const results = await svc.sendAlertChanges(changes);
-      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some(r => !r.success)).toBe(true);
     });
   });
 

--- a/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
+++ b/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
@@ -319,10 +319,335 @@ describe('MultiplatformNotificationService', () => {
 
       const testService = new MultiplatformNotificationService([throwingService]);
       const healthStatus = await testService.healthCheck();
-      
+
       expect(healthStatus).toEqual({
         throwing: false
       });
+    });
+  });
+
+  describe('getService', () => {
+    test('should return service by platform name', () => {
+      const service = multiService.getService('slack');
+      expect(service).toBeDefined();
+      expect(service!.platformName).toBe('slack');
+    });
+
+    test('should return undefined for non-existent platform', () => {
+      expect(multiService.getService('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('구독 기반 알림', () => {
+    test('sendAlertToSubscriptions: 구독자가 없으면 빈 배열 반환', async () => {
+      const alert = createMockAlert();
+      const results = await multiService.sendAlertToSubscriptions(alert);
+      expect(results).toEqual([]);
+    });
+
+    test('sendAlertToSubscriptions: 구독자에게 전송 (폴백)', async () => {
+      multiService.addSubscription('slack', 'user1', ['L1100000']);
+      const alert = createMockAlert({ REG_ID: 'L1100000' });
+      const results = await multiService.sendAlertToSubscriptions(alert);
+      expect(results.length).toBeGreaterThanOrEqual(0);
+    });
+
+    test('sendAlertChangeToSubscriptions: 구독자가 없으면 빈 배열 반환', async () => {
+      const change: AlertChange = {
+        type: 'NEW',
+        current: {
+          key: 'test', regionId: 'L1100000', regionName: '서울',
+          warningType: 'H', level: '2', command: '1',
+          announcedAt: '202601011200', effectiveAt: '202601011300',
+          lastUpdated: new Date().toISOString()
+        },
+        description: '신규 특보'
+      };
+      const results = await multiService.sendAlertChangeToSubscriptions(change);
+      expect(results).toEqual([]);
+    });
+
+    test('sendAlertChangesToSubscriptions: 빈 배열 반환', async () => {
+      const results = await multiService.sendAlertChangesToSubscriptions([]);
+      expect(results).toEqual([]);
+    });
+
+    test('addSubscription: 구독 추가', () => {
+      const id = multiService.addSubscription('slack', 'userA', ['L1100000'], {
+        warningTypes: ['H'], displayName: 'Test User'
+      });
+      expect(id).toBeTruthy();
+    });
+
+    test('removeSubscription: 구독 제거', () => {
+      multiService.addSubscription('slack', 'userB', ['L1100000']);
+      expect(multiService.removeSubscription('slack', 'userB')).toBe(true);
+      expect(multiService.removeSubscription('slack', 'nonexistent')).toBe(false);
+    });
+
+    test('getSubscriptionStatistics: 통계 반환', () => {
+      multiService.addSubscription('slack', 'userC', ['L1100000']);
+      const stats = multiService.getSubscriptionStatistics();
+      expect(stats.totalSubscriptions).toBeGreaterThanOrEqual(1);
+    });
+
+    test('getSubscriptionManager: 매니저 인스턴스 반환', () => {
+      const manager = multiService.getSubscriptionManager();
+      expect(manager).toBeDefined();
+    });
+  });
+
+  describe('하이브리드 구독 시스템', () => {
+    test('isHybridSubscriptionAvailable: false by default', () => {
+      expect(multiService.isHybridSubscriptionAvailable()).toBe(false);
+    });
+
+    test('getHybridSubscriptionManager: undefined by default', () => {
+      expect(multiService.getHybridSubscriptionManager()).toBeUndefined();
+    });
+
+    test('setHybridSubscriptionManager: sets and retrieves', () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue(['telegram']),
+        getHelpMessage: jest.fn().mockResolvedValue('help'),
+        getPlatformStats: jest.fn().mockResolvedValue({ total: 1 })
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      expect(multiService.isHybridSubscriptionAvailable()).toBe(true);
+      expect(multiService.getHybridSubscriptionManager()).toBe(mockHybridManager);
+    });
+
+    test('processSubscriptionCommand: without hybrid manager', async () => {
+      const result = await multiService.processSubscriptionCommand('telegram', 'u1', 'help');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HYBRID_SYSTEM_NOT_AVAILABLE');
+    });
+
+    test('processSubscriptionCommand: with hybrid manager', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn().mockResolvedValue({ success: true, message: 'OK' }),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const result = await multiService.processSubscriptionCommand('telegram', 'u1', 'help');
+      expect(result.success).toBe(true);
+    });
+
+    test('processSubscriptionCommand: handles errors', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn().mockRejectedValue(new Error('fail')),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const result = await multiService.processSubscriptionCommand('telegram', 'u1', 'help');
+      expect(result.success).toBe(false);
+    });
+
+    test('generateWebToken: without hybrid manager', async () => {
+      const token = await multiService.generateWebToken('telegram', 'u1');
+      expect(token).toBeNull();
+    });
+
+    test('generateWebToken: with hybrid manager', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn().mockResolvedValue({ token: 'abc123' }),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const token = await multiService.generateWebToken('telegram', 'u1');
+      expect(token).toBe('abc123');
+    });
+
+    test('getHybridSubscriptionStats: without hybrid manager', async () => {
+      const stats = await multiService.getHybridSubscriptionStats();
+      expect(stats).toBeNull();
+    });
+
+    test('getHybridSubscriptionStats: with hybrid manager', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn().mockResolvedValue({ total: 5 })
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const stats = await multiService.getHybridSubscriptionStats();
+      expect(stats).toEqual({ total: 5 });
+    });
+
+    test('getHybridPlatformNames: returns empty without manager', () => {
+      expect(multiService.getHybridPlatformNames()).toEqual([]);
+    });
+
+    test('getHybridPlatformNames: returns platforms with manager', () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue(['telegram', 'slack']),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      expect(multiService.getHybridPlatformNames()).toEqual(['telegram', 'slack']);
+    });
+
+    test('getHybridHelpMessage: without hybrid manager', async () => {
+      const help = await multiService.getHybridHelpMessage('telegram');
+      expect(help).toBeNull();
+    });
+
+    test('getHybridHelpMessage: with hybrid manager', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn().mockResolvedValue('telegram help'),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const help = await multiService.getHybridHelpMessage('telegram');
+      expect(help).toBe('telegram help');
+    });
+
+    test('generateWebToken: handles error gracefully', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn().mockRejectedValue(new Error('token error')),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const token = await multiService.generateWebToken('telegram', 'u1');
+      expect(token).toBeNull();
+    });
+
+    test('getHybridSubscriptionStats: handles error gracefully', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn(),
+        getPlatformStats: jest.fn().mockRejectedValue(new Error('stats error'))
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const stats = await multiService.getHybridSubscriptionStats();
+      expect(stats).toBeNull();
+    });
+
+    test('getHybridHelpMessage: handles error gracefully', async () => {
+      const mockHybridManager = {
+        processCommand: jest.fn(),
+        generateUserToken: jest.fn(),
+        getRegisteredPlatforms: jest.fn().mockReturnValue([]),
+        getHelpMessage: jest.fn().mockRejectedValue(new Error('help error')),
+        getPlatformStats: jest.fn()
+      } as any;
+
+      multiService.setHybridSubscriptionManager(mockHybridManager);
+      const help = await multiService.getHybridHelpMessage('telegram');
+      expect(help).toBeNull();
+    });
+  });
+
+  describe('서비스 없는 경우', () => {
+    let emptyService: MultiplatformNotificationService;
+
+    beforeEach(() => {
+      emptyService = new MultiplatformNotificationService([]);
+    });
+
+    test('sendAlertChange: 빈 배열 반환', async () => {
+      const change = createMockChange('NEW');
+      const results = await emptyService.sendAlertChange(change);
+      expect(results).toEqual([]);
+    });
+
+    test('sendAlertChanges: 빈 배열 반환', async () => {
+      const changes = [createMockChange('NEW')];
+      const results = await emptyService.sendAlertChanges(changes);
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('sendAlertChange 에러 처리', () => {
+    test('서비스 에러 시 에러 결과 반환', async () => {
+      const failService = new MockNotificationService('fail', true);
+      const svc = new MultiplatformNotificationService([failService]);
+      const change = createMockChange('NEW');
+      const results = await svc.sendAlertChange(change);
+      expect(results.length).toBe(1);
+      expect(results[0].success).toBe(false);
+    });
+  });
+
+  describe('sendAlertChanges 에러 처리', () => {
+    test('서비스 에러 시 에러 결과 반환', async () => {
+      const failService = new MockNotificationService('fail', true);
+      const svc = new MultiplatformNotificationService([failService]);
+      const changes = [createMockChange('NEW'), createMockChange('RESOLVED')];
+      const results = await svc.sendAlertChanges(changes);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('sendAlertWithRetry', () => {
+    test('성공 시 바로 반환', async () => {
+      const results = await multiService.sendAlertWithRetry(createMockAlert(), 2, 10);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every(r => r.success)).toBe(true);
+    });
+
+    test('실패 시 재시도 후 반환', async () => {
+      const failService = new MockNotificationService('fail', true);
+      const svc = new MultiplatformNotificationService([failService]);
+      const results = await svc.sendAlertWithRetry(createMockAlert(), 2, 10);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some(r => !r.success)).toBe(true);
+    });
+  });
+
+  describe('sendAlertToSubscriptions 상세', () => {
+    test('구독자의 플랫폼 서비스가 없으면 실패 결과 반환', async () => {
+      // discord 플랫폼 구독자를 추가하지만 discord 서비스는 등록하지 않음
+      multiService.addSubscription('discord', 'user1', ['L1100000']);
+      const alert = createMockAlert({ REG_ID: 'L1100000' });
+      const results = await multiService.sendAlertToSubscriptions(alert);
+      const discordResults = results.filter(r => r.platform === 'discord');
+      // discord 서비스가 없으므로 실패 결과
+      for (const r of discordResults) {
+        expect(r.success).toBe(false);
+      }
+    });
+  });
+
+  describe('sendAlertChangesToSubscriptions 상세', () => {
+    test('여러 변동 처리', async () => {
+      multiService.addSubscription('slack', 'userX', ['L1100000']);
+      const changes = [createMockChange('NEW'), createMockChange('RESOLVED')];
+      const results = await multiService.sendAlertChangesToSubscriptions(changes);
+      expect(results.length).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
+++ b/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
@@ -349,7 +349,7 @@ describe('MultiplatformNotificationService', () => {
       multiService.addSubscription('slack', 'user1', ['L1100000']);
       const alert = createMockAlert({ REG_ID: 'L1100000' });
       const results = await multiService.sendAlertToSubscriptions(alert);
-      expect(results.length).toBeGreaterThanOrEqual(0);
+      expect(results.length).toBeGreaterThan(0);
     });
 
     test('sendAlertChangeToSubscriptions: 구독자가 없으면 빈 배열 반환', async () => {
@@ -645,10 +645,11 @@ describe('MultiplatformNotificationService', () => {
 
   describe('sendAlertChangesToSubscriptions 상세', () => {
     test('여러 변동 처리', async () => {
-      multiService.addSubscription('slack', 'userX', ['L1100000']);
+      // createMockChange의 regionId(L1020110)와 일치하는 지역으로 구독
+      multiService.addSubscription('slack', 'userX', ['L1020110']);
       const changes = [createMockChange('NEW'), createMockChange('RESOLVED')];
       const results = await multiService.sendAlertChangesToSubscriptions(changes);
-      expect(results.length).toBeGreaterThanOrEqual(0);
+      expect(results.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
+++ b/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
@@ -635,7 +635,8 @@ describe('MultiplatformNotificationService', () => {
       const alert = createMockAlert({ REG_ID: 'L1100000' });
       const results = await multiService.sendAlertToSubscriptions(alert);
       const discordResults = results.filter(r => r.platform === 'discord');
-      // discord 서비스가 없으므로 실패 결과
+      // discord 서비스가 없으므로 실패 결과 (빈 배열이 아닌지 먼저 확인)
+      expect(discordResults.length).toBeGreaterThan(0);
       for (const r of discordResults) {
         expect(r.success).toBe(false);
       }

--- a/src/__tests__/services/notifications/NotificationFactory.test.ts
+++ b/src/__tests__/services/notifications/NotificationFactory.test.ts
@@ -89,6 +89,218 @@ describe('NotificationFactory', () => {
     });
   });
 
+  describe('createServices - 추가 케이스', () => {
+    test('Telegram 비활성화 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['telegram'],
+        telegram: {
+          enabled: false,
+          botToken: 'test-token'
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Telegram 설정 누락 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['telegram']
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Discord enabled 서비스 (미구현 - null 반환)', () => {
+      const config: NotificationConfig = {
+        platforms: ['discord'],
+        discord: {
+          enabled: true,
+          webhookUrl: 'https://discord.com/api/webhooks/test'
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Discord 비활성화 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['discord'],
+        discord: {
+          enabled: false,
+          webhookUrl: 'https://discord.com/api/webhooks/test'
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Discord 설정 누락 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['discord']
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Email enabled 서비스 (미구현 - null 반환)', () => {
+      const config: NotificationConfig = {
+        platforms: ['email'],
+        email: {
+          enabled: true,
+          smtpHost: 'smtp.test.com',
+          smtpPort: 587,
+          auth: { user: 'test@test.com', pass: 'pass' },
+          recipients: ['r@test.com']
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Email 비활성화 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['email'],
+        email: {
+          enabled: false,
+          smtpHost: 'smtp.test.com',
+          smtpPort: 587,
+          auth: { user: 'test@test.com', pass: 'pass' },
+          recipients: ['r@test.com']
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Email 설정 누락 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['email']
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Slack 검증 실패 시 생성하지 않음', () => {
+      const config: NotificationConfig = {
+        platforms: ['slack'],
+        slack: {
+          enabled: true,
+          webhookUrl: '',  // empty webhook URL causes validateConfig to fail
+          batchMode: false
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+
+    test('Telegram botToken 빈 문자열 시 검증 실패', () => {
+      const config: NotificationConfig = {
+        platforms: ['telegram'],
+        telegram: {
+          enabled: true,
+          botToken: ''  // empty bot token
+        }
+      };
+      const services = NotificationFactory.createServices(config);
+      expect(services).toHaveLength(0);
+    });
+  });
+
+  describe('validateConfig - 추가 케이스', () => {
+    test('Slack 설정 누락', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['slack']
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Slack 플랫폼이 선택되었지만 설정이 없습니다');
+    });
+
+    test('Telegram 설정 누락', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['telegram']
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Telegram 플랫폼이 선택되었지만 설정이 없습니다');
+    });
+
+    test('Telegram webhookUrl 있지만 webhookSecret 없는 경우', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['telegram'],
+        telegram: {
+          enabled: true,
+          botToken: 'test-token',
+          webhookUrl: 'https://example.com/webhook'
+          // webhookSecret 누락
+        }
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Telegram webhookSecret이 설정되지 않았습니다');
+    });
+
+    test('Discord 설정 누락', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['discord']
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Discord 플랫폼이 선택되었지만 설정이 없습니다');
+    });
+
+    test('Discord webhookUrl 누락', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['discord'],
+        discord: { enabled: true, webhookUrl: '' }
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Discord webhookUrl이 설정되지 않았습니다');
+    });
+
+    test('Email 설정 누락', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['email']
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Email 플랫폼이 선택되었지만 설정이 없습니다');
+    });
+
+    test('Email smtpPort 유효하지 않음', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['email'],
+        email: {
+          enabled: true,
+          smtpHost: 'smtp.test.com',
+          smtpPort: 0,
+          auth: { user: 'u', pass: 'p' },
+          recipients: ['r@t.com']
+        }
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('유효하지 않은 Email smtpPort입니다');
+    });
+
+    test('Email 인증 정보 누락', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['email'],
+        email: {
+          enabled: true,
+          smtpHost: 'smtp.test.com',
+          smtpPort: 587,
+          auth: { user: '', pass: '' },
+          recipients: ['r@t.com']
+        }
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Email 인증 정보가 올바르게 설정되지 않았습니다');
+    });
+
+    test('알 수 없는 플랫폼', () => {
+      const validation = NotificationFactory.validateConfig({
+        platforms: ['foobar']
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('지원하지 않는 알림 플랫폼: foobar');
+    });
+  });
+
   describe('createMultiplatformService', () => {
     test('MultiplatformNotificationService 생성', () => {
       const config: NotificationConfig = {

--- a/src/__tests__/services/notifications/TelegramNotificationService.test.ts
+++ b/src/__tests__/services/notifications/TelegramNotificationService.test.ts
@@ -284,12 +284,17 @@ describe('TelegramNotificationService', () => {
 
   describe('sendAlert - no subscribers', () => {
     it('should return success with no subscribers', async () => {
-      // Override mock to return no subscriptions
+      // 생성자 mock이 빈 구독자를 반환하도록 사전 설정
       const { SubscriptionManager } = require('../../../services/notifications/SubscriptionManager');
-      const mockInstance = SubscriptionManager.mock.results[SubscriptionManager.mock.results.length - 1]?.value;
-      if (mockInstance) {
-        mockInstance.getRelevantSubscriptions.mockReturnValue([]);
-      }
+      SubscriptionManager.mockImplementationOnce(() => ({
+        addSubscription: jest.fn(),
+        removeSubscription: jest.fn(),
+        getSubscriptions: jest.fn().mockReturnValue([]),
+        getRelevantSubscriptions: jest.fn().mockReturnValue([]),
+        getRelevantSubscriptionsForChange: jest.fn().mockReturnValue([]),
+        getUserSubscription: jest.fn(),
+        getSubscriptionsByPlatform: jest.fn().mockReturnValue([]),
+      }));
 
       const noSubService = new TelegramNotificationService({
         enabled: true,
@@ -313,10 +318,15 @@ describe('TelegramNotificationService', () => {
   describe('sendAlertChange - no subscribers', () => {
     it('should return success with no subscribers', async () => {
       const { SubscriptionManager } = require('../../../services/notifications/SubscriptionManager');
-      const mockInstance = SubscriptionManager.mock.results[SubscriptionManager.mock.results.length - 1]?.value;
-      if (mockInstance) {
-        mockInstance.getRelevantSubscriptionsForChange.mockReturnValue([]);
-      }
+      SubscriptionManager.mockImplementationOnce(() => ({
+        addSubscription: jest.fn(),
+        removeSubscription: jest.fn(),
+        getSubscriptions: jest.fn().mockReturnValue([]),
+        getRelevantSubscriptions: jest.fn().mockReturnValue([]),
+        getRelevantSubscriptionsForChange: jest.fn().mockReturnValue([]),
+        getUserSubscription: jest.fn(),
+        getSubscriptionsByPlatform: jest.fn().mockReturnValue([]),
+      }));
 
       const noSubService = new TelegramNotificationService({
         enabled: true,

--- a/src/__tests__/services/notifications/TelegramNotificationService.test.ts
+++ b/src/__tests__/services/notifications/TelegramNotificationService.test.ts
@@ -68,7 +68,8 @@ jest.mock('../../../services/subscriptions/TelegramSubscriptionInterface', () =>
     handleCommand: jest.fn().mockResolvedValue({
       success: true,
       message: 'Command executed successfully'
-    })
+    }),
+    setWebInterface: jest.fn()
   }))
 }));
 
@@ -281,6 +282,158 @@ describe('TelegramNotificationService', () => {
     });
   });
 
+  describe('sendAlert - no subscribers', () => {
+    it('should return success with no subscribers', async () => {
+      // Override mock to return no subscriptions
+      const { SubscriptionManager } = require('../../../services/notifications/SubscriptionManager');
+      const mockInstance = SubscriptionManager.mock.results[SubscriptionManager.mock.results.length - 1]?.value;
+      if (mockInstance) {
+        mockInstance.getRelevantSubscriptions.mockReturnValue([]);
+      }
+
+      const noSubService = new TelegramNotificationService({
+        enabled: true,
+        botToken: 'test-token'
+      });
+
+      const result = await noSubService.sendAlert({
+        REG_ID: '11B00000', REG_UP: '11000000', REG_KO: '서울',
+        REG_UP_KO: '서울특별시', REG_NAME: '서울특별시',
+        TM_FC: '202501281200', TM_EF: '202501281300',
+        TM_IN: '202501281200', STN: '108', WRN: 'H', LVL: '2',
+        CMD: '1', GRD: '', CNT: '1', RPT: '1',
+        TM_ST: '202501281300', TM_ED: '202501291200',
+        REG_SP: '', STN_ID: '108', TM_SEQ: '1', MAN_FC: '', MAN_IN: ''
+      });
+      expect(result.success).toBe(true);
+      expect(result.platform).toBe('telegram');
+    });
+  });
+
+  describe('sendAlertChange - no subscribers', () => {
+    it('should return success with no subscribers', async () => {
+      const { SubscriptionManager } = require('../../../services/notifications/SubscriptionManager');
+      const mockInstance = SubscriptionManager.mock.results[SubscriptionManager.mock.results.length - 1]?.value;
+      if (mockInstance) {
+        mockInstance.getRelevantSubscriptionsForChange.mockReturnValue([]);
+      }
+
+      const noSubService = new TelegramNotificationService({
+        enabled: true,
+        botToken: 'test-token'
+      });
+
+      const result = await noSubService.sendAlertChange({
+        type: 'NEW',
+        current: {
+          key: 'test', regionId: '11B00000', regionName: '서울',
+          warningType: 'H', level: '2', command: '1',
+          announcedAt: '202501281200', effectiveAt: '202501281300',
+          lastUpdated: '202501281200'
+        },
+        description: '테스트'
+      });
+      expect(result.success).toBe(true);
+      expect(result.platform).toBe('telegram');
+    });
+  });
+
+  describe('processWebhookUpdate', () => {
+    it('should process message update', async () => {
+      const update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          date: Date.now() / 1000,
+          chat: { id: 123, type: 'private' as const },
+          text: '/help'
+        }
+      };
+      await expect(service.processWebhookUpdate(update)).resolves.not.toThrow();
+    });
+
+    it('should process callback query update', async () => {
+      const update = {
+        update_id: 2,
+        callback_query: {
+          id: 'cb1',
+          from: { id: 123, is_bot: false, first_name: 'Test' },
+          chat_instance: 'test',
+          data: 'subscribe:seoul',
+          message: {
+            message_id: 1,
+            date: Date.now() / 1000,
+            chat: { id: 123, type: 'private' as const }
+          }
+        }
+      };
+      await expect(service.processWebhookUpdate(update)).resolves.not.toThrow();
+    });
+
+    it('should ignore non-command message', async () => {
+      const update = {
+        update_id: 3,
+        message: {
+          message_id: 1,
+          date: Date.now() / 1000,
+          chat: { id: 123, type: 'private' as const },
+          text: 'Hello world'
+        }
+      };
+      await expect(service.processWebhookUpdate(update)).resolves.not.toThrow();
+    });
+  });
+
+  describe('stop', () => {
+    it('should stop bot without error', async () => {
+      await expect(service.stop()).resolves.not.toThrow();
+    });
+  });
+
+  describe('setWebInterface', () => {
+    it('should set web interface without error', () => {
+      const mockWebInterface = {} as any;
+      expect(() => service.setWebInterface(mockWebInterface)).not.toThrow();
+    });
+  });
+
+  describe('getSubscriptionManager', () => {
+    it('should return subscription manager', () => {
+      expect(service.getSubscriptionManager()).toBeDefined();
+    });
+  });
+
+  describe('constructor options', () => {
+    it('should work without chatId (no legacy)', () => {
+      const s = new TelegramNotificationService({
+        enabled: true,
+        botToken: 'test-token'
+      });
+      expect(s.platformName).toBe('telegram');
+    });
+
+    it('should accept webhookUrl and webDashboardUrl', () => {
+      const s = new TelegramNotificationService({
+        enabled: true,
+        botToken: 'test-token',
+        webhookUrl: 'https://example.com/webhook',
+        webDashboardUrl: 'https://dashboard.example.com'
+      });
+      expect(s.platformName).toBe('telegram');
+    });
+
+    it('should accept external subscription manager', () => {
+      const { SubscriptionManager } = require('../../../services/notifications/SubscriptionManager');
+      const externalManager = new SubscriptionManager();
+      const s = new TelegramNotificationService(
+        { enabled: true, botToken: 'test-token' },
+        undefined,
+        externalManager
+      );
+      expect(s.platformName).toBe('telegram');
+    });
+  });
+
   describe('formatting methods', () => {
     it('should format weather alert with proper environment prefix', () => {
       const mockAlert: WeatherAlert = {
@@ -354,6 +507,82 @@ describe('TelegramNotificationService', () => {
       expect(formattedMessage).toContain('주의보 → 경보');
       expect(formattedMessage).toContain('서울특별시');
       expect(formattedMessage).toContain('폭염');
+    });
+
+    it('should format RESOLVED alert change', () => {
+      const change: AlertChange = {
+        type: 'RESOLVED',
+        previous: {
+          key: 'k1', regionId: '11B00000', regionName: '서울특별시',
+          warningType: 'H', level: '2', command: '3',
+          announcedAt: '202501281200', effectiveAt: '202501281300',
+          lastUpdated: '202501281200'
+        },
+        description: '해제'
+      };
+      const msg = (service as any).formatAlertChange(change);
+      expect(msg).toContain('✅');
+      expect(msg).toContain('특보 해제');
+      expect(msg).toContain('해제수준');
+    });
+
+    it('should format TIME_EXTENDED alert change', () => {
+      const change: AlertChange = {
+        type: 'TIME_EXTENDED',
+        current: {
+          key: 'k1', regionId: '11B00000', regionName: '서울특별시',
+          warningType: 'H', level: '2', command: '2',
+          announcedAt: '202501281200', effectiveAt: '202501291300',
+          lastUpdated: '202501281200'
+        },
+        description: '시간 연장'
+      };
+      const msg = (service as any).formatAlertChange(change);
+      expect(msg).toContain('⏰');
+      expect(msg).toContain('시간 연장');
+      expect(msg).toContain('발효시각');
+    });
+
+    it('should format MODIFIED alert change', () => {
+      const change: AlertChange = {
+        type: 'MODIFIED',
+        current: {
+          key: 'k1', regionId: '11B00000', regionName: '서울특별시',
+          warningType: 'R', level: '3', command: '2',
+          announcedAt: '202501281200', effectiveAt: '202501281300',
+          lastUpdated: '202501281200'
+        },
+        description: '내용 변경'
+      };
+      const msg = (service as any).formatAlertChange(change);
+      expect(msg).toContain('🔄');
+      expect(msg).toContain('내용 변경');
+    });
+
+    it('should format weather info with all fields', () => {
+      const forecast = {
+        temperature: 35,
+        feelsLike: 38,
+        precipitationProbability: 20,
+        humidity: 70
+      };
+      const msg = (service as any).formatWeatherInfo(forecast);
+      expect(msg).toContain('35°C');
+      expect(msg).toContain('체감 38°C');
+      expect(msg).toContain('20%');
+      expect(msg).toContain('70%');
+    });
+
+    it('should return empty string for empty forecast', () => {
+      const msg = (service as any).formatWeatherInfo({});
+      expect(msg).toBe('');
+    });
+
+    it('should not show feelsLike when same as temperature', () => {
+      const forecast = { temperature: 35, feelsLike: 35 };
+      const msg = (service as any).formatWeatherInfo(forecast);
+      expect(msg).toContain('35°C');
+      expect(msg).not.toContain('체감');
     });
   });
 });

--- a/src/__tests__/services/subscriptions/CommandParser.test.ts
+++ b/src/__tests__/services/subscriptions/CommandParser.test.ts
@@ -1,0 +1,362 @@
+import { CommonCommandParser, REGION_MAPPINGS, WARNING_TYPE_MAPPINGS } from '../../../services/subscriptions/CommandParser';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+describe('CommonCommandParser', () => {
+  let parser: CommonCommandParser;
+
+  beforeEach(() => {
+    parser = new CommonCommandParser();
+  });
+
+  describe('parseCommand', () => {
+    it('should parse subscribe command with args', () => {
+      const result = parser.parseCommand('subscribe seoul heat', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+      expect(result!.args).toEqual(['seoul', 'heat']);
+      expect(result!.platform).toBe('slack');
+      expect(result!.userId).toBe('user1');
+    });
+
+    it('should parse Korean commands', () => {
+      const result = parser.parseCommand('구독 서울', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+    });
+
+    it('should parse abbreviated commands', () => {
+      const result = parser.parseCommand('sub seoul', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+    });
+
+    it('should parse unsubscribe command', () => {
+      const result = parser.parseCommand('unsub', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('unsubscribe');
+    });
+
+    it('should parse list command', () => {
+      const result = parser.parseCommand('목록', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('list');
+    });
+
+    it('should parse settings command', () => {
+      const result = parser.parseCommand('설정', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('settings');
+    });
+
+    it('should parse quiet command', () => {
+      const result = parser.parseCommand('quiet 22:00 08:00', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('quiet');
+      expect(result!.args).toEqual(['22:00', '08:00']);
+    });
+
+    it('should parse status command', () => {
+      const result = parser.parseCommand('상태', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('status');
+    });
+
+    it('should parse help with ?', () => {
+      const result = parser.parseCommand('?', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('help');
+    });
+
+    it('should return null for empty message', () => {
+      expect(parser.parseCommand('', 'slack', 'user1')).toBeNull();
+    });
+
+    it('should return null for unknown command', () => {
+      expect(parser.parseCommand('xyz', 'slack', 'user1')).toBeNull();
+    });
+
+    it('should handle extra whitespace', () => {
+      const result = parser.parseCommand('  subscribe   seoul  ', 'slack', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+      expect(result!.args).toEqual(['seoul']);
+    });
+
+    it('should strip telegram prefix', () => {
+      const result = parser.parseCommand('/subscribe seoul', 'telegram', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+    });
+
+    it('should strip discord prefix', () => {
+      const result = parser.parseCommand('!weather subscribe seoul', 'discord', 'user1');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+    });
+
+    it('should preserve rawMessage', () => {
+      const raw = 'SUBSCRIBE Seoul Heat';
+      const result = parser.parseCommand(raw, 'slack', 'user1');
+      expect(result!.rawMessage).toBe(raw);
+    });
+  });
+
+  describe('validateCommand', () => {
+    it('should require at least 1 arg for subscribe', () => {
+      expect(parser.validateCommand({
+        command: 'subscribe', platform: 'slack', userId: 'u1', args: []
+      })).toBe(false);
+
+      expect(parser.validateCommand({
+        command: 'subscribe', platform: 'slack', userId: 'u1', args: ['seoul']
+      })).toBe(true);
+    });
+
+    it('should accept unsubscribe without args', () => {
+      expect(parser.validateCommand({
+        command: 'unsubscribe', platform: 'slack', userId: 'u1', args: []
+      })).toBe(true);
+    });
+
+    it('should require 2 valid time args for quiet', () => {
+      expect(parser.validateCommand({
+        command: 'quiet', platform: 'slack', userId: 'u1', args: ['22:00', '08:00']
+      })).toBe(true);
+
+      expect(parser.validateCommand({
+        command: 'quiet', platform: 'slack', userId: 'u1', args: ['22:00']
+      })).toBe(false);
+
+      expect(parser.validateCommand({
+        command: 'quiet', platform: 'slack', userId: 'u1', args: ['25:00', '08:00']
+      })).toBe(false);
+    });
+
+    it('should accept list/settings/status/help without args', () => {
+      for (const cmd of ['list', 'settings', 'status', 'help'] as const) {
+        expect(parser.validateCommand({
+          command: cmd, platform: 'slack', userId: 'u1', args: []
+        })).toBe(true);
+      }
+    });
+  });
+
+  describe('suggestCommands', () => {
+    it('should suggest commands starting with prefix', () => {
+      expect(parser.suggestCommands('sub')).toEqual(['subscribe']);
+      expect(parser.suggestCommands('un')).toEqual(['unsubscribe']);
+      expect(parser.suggestCommands('s')).toContain('subscribe');
+      expect(parser.suggestCommands('s')).toContain('settings');
+      expect(parser.suggestCommands('s')).toContain('status');
+    });
+
+    it('should return all commands for empty prefix', () => {
+      expect(parser.suggestCommands('')).toHaveLength(7);
+    });
+  });
+
+  describe('parseRegion', () => {
+    it('should parse English region names', () => {
+      expect(parser.parseRegion('seoul')).toEqual({ code: 'L1100000', name: '서울특별시' });
+      expect(parser.parseRegion('busan')).toEqual({ code: 'L1150000', name: '부산광역시' });
+      expect(parser.parseRegion('jeju')).toEqual({ code: 'L1090000', name: '제주특별자치도' });
+    });
+
+    it('should parse Korean region names', () => {
+      expect(parser.parseRegion('서울')).toEqual({ code: 'L1100000', name: '서울특별시' });
+      expect(parser.parseRegion('부산')).toEqual({ code: 'L1150000', name: '부산광역시' });
+    });
+
+    it('should parse nationwide', () => {
+      const result = parser.parseRegion('all');
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('');
+      expect(result!.name).toBe('전국');
+    });
+
+    it('should be case-insensitive', () => {
+      expect(parser.parseRegion('Seoul')).toEqual({ code: 'L1100000', name: '서울특별시' });
+      expect(parser.parseRegion('BUSAN')).toEqual({ code: 'L1150000', name: '부산광역시' });
+    });
+
+    it('should return null for unknown region', () => {
+      expect(parser.parseRegion('mars')).toBeNull();
+    });
+  });
+
+  describe('parseWarningType', () => {
+    it('should parse English warning names', () => {
+      expect(parser.parseWarningType('heat')).toEqual({ code: 'H', name: '폭염' });
+      expect(parser.parseWarningType('rain')).toEqual({ code: 'R', name: '호우' });
+      expect(parser.parseWarningType('typhoon')).toEqual({ code: 'T', name: '태풍' });
+    });
+
+    it('should parse Korean warning names', () => {
+      expect(parser.parseWarningType('폭염')).toEqual({ code: 'H', name: '폭염' });
+      expect(parser.parseWarningType('호우')).toEqual({ code: 'R', name: '호우' });
+    });
+
+    it('should parse single-letter codes', () => {
+      expect(parser.parseWarningType('H')).toEqual({ code: 'H', name: '폭염' });
+      expect(parser.parseWarningType('R')).toEqual({ code: 'R', name: '호우' });
+    });
+
+    it('should parse all type', () => {
+      const result = parser.parseWarningType('all');
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('');
+    });
+
+    it('should return null for unknown type', () => {
+      expect(parser.parseWarningType('earthquake')).toBeNull();
+    });
+  });
+
+  describe('parseWarningLevel', () => {
+    it('should parse numeric levels', () => {
+      expect(parser.parseWarningLevel('1')).toBe('1');
+      expect(parser.parseWarningLevel('2')).toBe('2');
+      expect(parser.parseWarningLevel('3')).toBe('3');
+    });
+
+    it('should parse English level names', () => {
+      expect(parser.parseWarningLevel('preliminary')).toBe('1');
+      expect(parser.parseWarningLevel('advisory')).toBe('2');
+      expect(parser.parseWarningLevel('warning')).toBe('3');
+    });
+
+    it('should parse Korean level names', () => {
+      expect(parser.parseWarningLevel('예비')).toBe('1');
+      expect(parser.parseWarningLevel('주의보')).toBe('2');
+      expect(parser.parseWarningLevel('경보')).toBe('3');
+    });
+
+    it('should return null for unknown level', () => {
+      expect(parser.parseWarningLevel('extreme')).toBeNull();
+    });
+  });
+
+  describe('validateTimeFormat', () => {
+    it('should accept valid HH:MM formats', () => {
+      expect(parser.validateTimeFormat('00:00')).toBe(true);
+      expect(parser.validateTimeFormat('23:59')).toBe(true);
+      expect(parser.validateTimeFormat('8:30')).toBe(true);
+      expect(parser.validateTimeFormat('12:00')).toBe(true);
+    });
+
+    it('should reject invalid formats', () => {
+      expect(parser.validateTimeFormat('25:00')).toBe(false);
+      expect(parser.validateTimeFormat('12:60')).toBe(false);
+      expect(parser.validateTimeFormat('abc')).toBe(false);
+      expect(parser.validateTimeFormat('')).toBe(false);
+      expect(parser.validateTimeFormat('12')).toBe(false);
+    });
+  });
+
+  describe('formatSubscriptionSummary', () => {
+    it('should format subscription with regions and warnings', () => {
+      const summary = parser.formatSubscriptionSummary({
+        id: '1', platform: 'slack', userId: 'u1',
+        targetRegions: ['L1100000'],
+        warningTypes: ['H'],
+        enabled: true, createdAt: new Date(), updatedAt: new Date()
+      });
+      expect(summary).toContain('서울특별시');
+      expect(summary).toContain('폭염');
+    });
+
+    it('should show 전국 when no regions', () => {
+      const summary = parser.formatSubscriptionSummary({
+        id: '1', platform: 'slack', userId: 'u1',
+        targetRegions: [],
+        warningTypes: [],
+        enabled: true, createdAt: new Date(), updatedAt: new Date()
+      });
+      expect(summary).toContain('전국');
+      expect(summary).toContain('전체');
+    });
+
+    it('should show quiet hours when set', () => {
+      const summary = parser.formatSubscriptionSummary({
+        id: '1', platform: 'slack', userId: 'u1',
+        targetRegions: [], warningTypes: [],
+        enabled: true, createdAt: new Date(), updatedAt: new Date(),
+        preferences: { quietHours: { start: '22:00', end: '08:00' } }
+      });
+      expect(summary).toContain('22:00');
+      expect(summary).toContain('08:00');
+    });
+
+    it('should show min level when set', () => {
+      const summary = parser.formatSubscriptionSummary({
+        id: '1', platform: 'slack', userId: 'u1',
+        targetRegions: [], warningTypes: [],
+        enabled: true, createdAt: new Date(), updatedAt: new Date(),
+        preferences: { minLevel: '2' }
+      });
+      expect(summary).toContain('주의보');
+    });
+  });
+
+  describe('generateHelpMessage', () => {
+    it('should include command prefix for telegram', () => {
+      const help = parser.generateHelpMessage('telegram');
+      expect(help).toContain('/subscribe');
+    });
+
+    it('should include command prefix for discord', () => {
+      const help = parser.generateHelpMessage('discord');
+      expect(help).toContain('!weather subscribe');
+    });
+
+    it('should not include prefix for slack', () => {
+      const help = parser.generateHelpMessage('slack');
+      expect(help).toContain('subscribe');
+      expect(help).not.toContain('/subscribe');
+    });
+  });
+
+  describe('REGION_MAPPINGS', () => {
+    it('should have all major regions', () => {
+      expect(REGION_MAPPINGS).toHaveProperty('seoul');
+      expect(REGION_MAPPINGS).toHaveProperty('busan');
+      expect(REGION_MAPPINGS).toHaveProperty('jeju');
+      expect(REGION_MAPPINGS).toHaveProperty('nationwide');
+    });
+
+    it('should have valid region codes', () => {
+      for (const [key, mapping] of Object.entries(REGION_MAPPINGS)) {
+        if (key !== 'nationwide') {
+          expect(mapping.code).toMatch(/^L\d{7}$/);
+        }
+        expect(mapping.name).toBeTruthy();
+        expect(mapping.aliases.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('WARNING_TYPE_MAPPINGS', () => {
+    it('should have all warning types', () => {
+      expect(WARNING_TYPE_MAPPINGS).toHaveProperty('heat');
+      expect(WARNING_TYPE_MAPPINGS).toHaveProperty('rain');
+      expect(WARNING_TYPE_MAPPINGS).toHaveProperty('typhoon');
+      expect(WARNING_TYPE_MAPPINGS).toHaveProperty('all');
+    });
+
+    it('should have single-letter codes', () => {
+      for (const [key, mapping] of Object.entries(WARNING_TYPE_MAPPINGS)) {
+        if (key !== 'all') {
+          expect(mapping.code).toMatch(/^[A-Z]$/);
+        }
+      }
+    });
+  });
+});

--- a/src/__tests__/services/subscriptions/EmailCommandProcessor.test.ts
+++ b/src/__tests__/services/subscriptions/EmailCommandProcessor.test.ts
@@ -1,0 +1,384 @@
+import { EmailCommandProcessor } from '../../../services/subscriptions/EmailCommandProcessor';
+import { SubscriptionManager } from '../../../services/notifications/SubscriptionManager';
+import { WebSubscriptionInterface } from '../../../services/subscriptions/WebSubscriptionInterface';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+describe('EmailCommandProcessor', () => {
+  let subManager: SubscriptionManager;
+  let processor: EmailCommandProcessor;
+  let mockWebInterface: jest.Mocked<Pick<WebSubscriptionInterface, 'generateAccessToken'>>;
+
+  beforeEach(() => {
+    subManager = new SubscriptionManager();
+    mockWebInterface = {
+      generateAccessToken: jest.fn().mockResolvedValue({
+        token: 'test-web-token-abc123',
+        platform: 'email', userId: 'test@example.com',
+        expiresAt: new Date(Date.now() + 86400000), createdAt: new Date()
+      })
+    };
+    processor = new EmailCommandProcessor(
+      subManager, undefined, mockWebInterface as any
+    );
+  });
+
+  describe('constructor', () => {
+    it('should initialize with default dashboard URL', () => {
+      const p = new EmailCommandProcessor(subManager);
+      expect(p.platformName).toBe('email');
+    });
+
+    it('should accept custom dashboard URL', () => {
+      const p = new EmailCommandProcessor(subManager, undefined, undefined, 'https://custom.url');
+      expect(p.platformName).toBe('email');
+    });
+  });
+
+  describe('setWebInterface', () => {
+    it('should set the web interface', () => {
+      const p = new EmailCommandProcessor(subManager);
+      p.setWebInterface(mockWebInterface as any);
+      // Should not throw
+    });
+  });
+
+  describe('handleCommand', () => {
+    describe('subscribe', () => {
+      it('should subscribe to a region', async () => {
+        const result = await processor.handleCommand({
+          command: 'subscribe', platform: 'email', userId: 'test@example.com',
+          args: ['seoul']
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('서울');
+      });
+
+      it('should subscribe to a region with warning type', async () => {
+        const result = await processor.handleCommand({
+          command: 'subscribe', platform: 'email', userId: 'test@example.com',
+          args: ['seoul', 'heat']
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('폭염');
+      });
+
+      it('should fail with invalid region', async () => {
+        const result = await processor.handleCommand({
+          command: 'subscribe', platform: 'email', userId: 'test@example.com',
+          args: ['mars']
+        });
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('INVALID_REGION');
+      });
+
+      it('should fail without region arg', async () => {
+        const result = await processor.handleCommand({
+          command: 'subscribe', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('INVALID_COMMAND_FORMAT');
+      });
+
+      it('should merge with existing subscription regions', async () => {
+        subManager.addSubscription({
+          platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000'], warningTypes: [],
+          enabled: true, displayName: 'Test'
+        });
+
+        await processor.handleCommand({
+          command: 'subscribe', platform: 'email', userId: 'test@example.com',
+          args: ['busan']
+        });
+
+        const sub = subManager.getUserSubscription('email', 'test@example.com');
+        expect(sub!.targetRegions).toContain('L1100000');
+        expect(sub!.targetRegions).toContain('L1150000');
+      });
+
+      it('should handle "all" warning type by clearing warning types', async () => {
+        const result = await processor.handleCommand({
+          command: 'subscribe', platform: 'email', userId: 'test@example.com',
+          args: ['seoul', 'all']
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('모든 특보');
+      });
+    });
+
+    describe('unsubscribe', () => {
+      it('should fail when no subscription exists', async () => {
+        const result = await processor.handleCommand({
+          command: 'unsubscribe', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('NO_SUBSCRIPTION');
+      });
+
+      it('should remove all subscriptions without args', async () => {
+        subManager.addSubscription({
+          platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000'], warningTypes: [],
+          enabled: true, displayName: 'Test'
+        });
+
+        const result = await processor.handleCommand({
+          command: 'unsubscribe', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(true);
+        expect(subManager.getUserSubscription('email', 'test@example.com')).toBeUndefined();
+      });
+
+      it('should remove specific region', async () => {
+        subManager.addSubscription({
+          platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000', 'L1150000'], warningTypes: [],
+          enabled: true, displayName: 'Test'
+        });
+
+        const result = await processor.handleCommand({
+          command: 'unsubscribe', platform: 'email', userId: 'test@example.com',
+          args: ['seoul']
+        });
+        expect(result.success).toBe(true);
+
+        const sub = subManager.getUserSubscription('email', 'test@example.com');
+        expect(sub!.targetRegions).not.toContain('L1100000');
+        expect(sub!.targetRegions).toContain('L1150000');
+      });
+
+      it('should remove subscription when last region removed', async () => {
+        subManager.addSubscription({
+          platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000'], warningTypes: [],
+          enabled: true, displayName: 'Test'
+        });
+
+        const result = await processor.handleCommand({
+          command: 'unsubscribe', platform: 'email', userId: 'test@example.com',
+          args: ['seoul']
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('모든 구독이 제거');
+      });
+
+      it('should fail with invalid region', async () => {
+        subManager.addSubscription({
+          platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000'], warningTypes: [],
+          enabled: true, displayName: 'Test'
+        });
+
+        const result = await processor.handleCommand({
+          command: 'unsubscribe', platform: 'email', userId: 'test@example.com',
+          args: ['mars']
+        });
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('INVALID_REGION');
+      });
+    });
+
+    describe('status/list', () => {
+      it('should show status with subscription', async () => {
+        subManager.addSubscription({
+          platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000'], warningTypes: ['H'],
+          enabled: true, displayName: 'Test'
+        });
+
+        const result = await processor.handleCommand({
+          command: 'status', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('구독 현황');
+        expect(result.message).toContain('test-web-token');
+      });
+
+      it('should show status without subscription', async () => {
+        const result = await processor.handleCommand({
+          command: 'status', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('구독 중인 알림이 없습니다');
+      });
+
+      it('should handle list as alias for status', async () => {
+        const result = await processor.handleCommand({
+          command: 'list', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe('help', () => {
+      it('should return help message', async () => {
+        const result = await processor.handleCommand({
+          command: 'help', platform: 'email', userId: 'test@example.com',
+          args: []
+        });
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('도움말');
+      });
+    });
+
+    describe('unknown command', () => {
+      it('should return error for unsupported command', async () => {
+        const result = await processor.handleCommand({
+          command: 'quiet' as any, platform: 'email', userId: 'test@example.com',
+          args: ['22:00', '08:00']
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe('extractCommand', () => {
+    it('should extract command from Re: subject', () => {
+      const result = processor.extractCommand(
+        'Re: 기상특보 - SUBSCRIBE seoul heat',
+        'From: test@example.com'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+      expect(result!.args).toContain('seoul');
+    });
+
+    it('should extract command from direct subject', () => {
+      const result = processor.extractCommand(
+        'SUBSCRIBE seoul',
+        'From: test@example.com'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+    });
+
+    it('should extract command from body when subject has no command', () => {
+      const result = processor.extractCommand(
+        'Random subject',
+        'SUBSCRIBE seoul\nFrom: test@example.com'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('subscribe');
+    });
+
+    it('should extract From email as userId', () => {
+      const result = processor.extractCommand(
+        'STATUS',
+        'Some body\nFrom: user@test.com'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe('user@test.com');
+    });
+
+    it('should use default userId when no From header', () => {
+      const result = processor.extractCommand(
+        'STATUS',
+        'No from header here'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe('unknown@email.com');
+    });
+
+    it('should return null when no command found', () => {
+      const result = processor.extractCommand(
+        'Random subject',
+        'Random body with no commands'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty inputs', () => {
+      expect(processor.extractCommand('', '')).toBeNull();
+    });
+  });
+
+  describe('createResponseEmail', () => {
+    it('should create success email', () => {
+      const email = processor.createResponseEmail(
+        { success: true, message: '구독 추가 완료' },
+        'test@example.com'
+      );
+      expect(email.subject).toContain('성공');
+      expect(email.html).toContain('구독 추가 완료');
+      expect(email.text).toContain('구독 추가 완료');
+    });
+
+    it('should create failure email', () => {
+      const email = processor.createResponseEmail(
+        { success: false, message: '잘못된 명령어', error: 'INVALID' },
+        'test@example.com'
+      );
+      expect(email.subject).toContain('실패');
+      expect(email.html).toContain('error');
+    });
+
+    it('should include HTML help section', () => {
+      const email = processor.createResponseEmail(
+        { success: true, message: 'OK' },
+        'test@example.com'
+      );
+      expect(email.html).toContain('SUBSCRIBE');
+      expect(email.html).toContain('UNSUBSCRIBE');
+    });
+  });
+
+  describe('createConfirmationEmail', () => {
+    it('should include subscription summary', async () => {
+      const email = await processor.createConfirmationEmail(
+        {
+          id: '1', platform: 'email', userId: 'test@example.com',
+          targetRegions: ['L1100000'], warningTypes: ['H'],
+          enabled: true, createdAt: new Date(), updatedAt: new Date()
+        },
+        'test@example.com'
+      );
+      expect(email.subject).toContain('구독 설정 확인');
+      expect(email.text).toContain('서울');
+      expect(email.html).toContain('test-web-token');
+    });
+  });
+
+  describe('generateAuthToken', () => {
+    it('should return a valid auth token', async () => {
+      const token = await processor.generateAuthToken('test@example.com');
+      expect(token.platform).toBe('email');
+      expect(token.userId).toBe('test@example.com');
+      expect(token.token).toBeTruthy();
+    });
+  });
+
+  describe('notifySubscriptionChange', () => {
+    it('should not throw with SMTP config', async () => {
+      const p = new EmailCommandProcessor(subManager, { host: 'smtp.test.com' });
+      await expect(p.notifySubscriptionChange('user@test.com', 'test change')).resolves.not.toThrow();
+    });
+
+    it('should not throw without SMTP config', async () => {
+      await expect(processor.notifySubscriptionChange('user@test.com', 'test change')).resolves.not.toThrow();
+    });
+  });
+
+  describe('getHelpMessage', () => {
+    it('should return help text with commands', () => {
+      const help = processor.getHelpMessage();
+      expect(help).toContain('SUBSCRIBE');
+      expect(help).toContain('UNSUBSCRIBE');
+      expect(help).toContain('STATUS');
+      expect(help).toContain('HELP');
+    });
+  });
+});

--- a/src/__tests__/services/subscriptions/HybridSubscriptionManager.test.ts
+++ b/src/__tests__/services/subscriptions/HybridSubscriptionManager.test.ts
@@ -1,0 +1,248 @@
+import { HybridSubscriptionManager } from '../../../services/subscriptions/HybridSubscriptionManager';
+import { SubscriptionManager } from '../../../services/notifications/SubscriptionManager';
+import { PlatformSubscriptionInterface, SubscriptionCommandParams, UserAuthToken } from '../../../services/subscriptions/interfaces';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+function createMockPlatformInterface(name: string): PlatformSubscriptionInterface {
+  return {
+    platformName: name,
+    handleCommand: jest.fn().mockResolvedValue({ success: true, message: `${name} OK` }),
+    generateAuthToken: jest.fn().mockResolvedValue({
+      token: `${name}-token`, platform: name, userId: 'u1',
+      expiresAt: new Date(Date.now() + 86400000), createdAt: new Date()
+    }),
+    notifySubscriptionChange: jest.fn().mockResolvedValue(undefined),
+    getHelpMessage: jest.fn().mockReturnValue(`${name} help message`)
+  };
+}
+
+describe('HybridSubscriptionManager', () => {
+  let subManager: SubscriptionManager;
+  let hybridManager: HybridSubscriptionManager;
+
+  beforeEach(() => {
+    subManager = new SubscriptionManager();
+    hybridManager = new HybridSubscriptionManager(subManager);
+  });
+
+  describe('constructor', () => {
+    it('should initialize with no registered platforms', () => {
+      expect(hybridManager.getRegisteredPlatforms()).toEqual([]);
+      expect(hybridManager.isWebInterfaceAvailable()).toBe(false);
+    });
+  });
+
+  describe('registerPlatformInterface', () => {
+    it('should register a platform', () => {
+      const mock = createMockPlatformInterface('telegram');
+      hybridManager.registerPlatformInterface('telegram', mock);
+      expect(hybridManager.getRegisteredPlatforms()).toContain('telegram');
+    });
+
+    it('should register multiple platforms', () => {
+      hybridManager.registerPlatformInterface('telegram', createMockPlatformInterface('telegram'));
+      hybridManager.registerPlatformInterface('slack', createMockPlatformInterface('slack'));
+      expect(hybridManager.getRegisteredPlatforms()).toHaveLength(2);
+    });
+  });
+
+  describe('registerWebInterface', () => {
+    it('should mark web interface as available', () => {
+      const mockWeb = {} as any;
+      hybridManager.registerWebInterface(mockWeb);
+      expect(hybridManager.isWebInterfaceAvailable()).toBe(true);
+    });
+  });
+
+  describe('processCommand', () => {
+    it('should delegate to the correct platform interface', async () => {
+      const mock = createMockPlatformInterface('telegram');
+      hybridManager.registerPlatformInterface('telegram', mock);
+
+      const params: SubscriptionCommandParams = {
+        command: 'subscribe', platform: 'telegram', userId: 'u1', args: ['seoul']
+      };
+
+      const result = await hybridManager.processCommand(params);
+      expect(result.success).toBe(true);
+      expect(mock.handleCommand).toHaveBeenCalledWith(params);
+    });
+
+    it('should return error for unsupported platform', async () => {
+      const params: SubscriptionCommandParams = {
+        command: 'subscribe', platform: 'unknown', userId: 'u1', args: []
+      };
+
+      const result = await hybridManager.processCommand(params);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('UNSUPPORTED_PLATFORM');
+    });
+
+    it('should handle platform interface errors', async () => {
+      const mock = createMockPlatformInterface('telegram');
+      (mock.handleCommand as jest.Mock).mockRejectedValue(new Error('boom'));
+      hybridManager.registerPlatformInterface('telegram', mock);
+
+      const params: SubscriptionCommandParams = {
+        command: 'subscribe', platform: 'telegram', userId: 'u1', args: []
+      };
+
+      const result = await hybridManager.processCommand(params);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('boom');
+    });
+
+    it('should log success for successful commands', async () => {
+      const mock = createMockPlatformInterface('slack');
+      hybridManager.registerPlatformInterface('slack', mock);
+
+      await hybridManager.processCommand({
+        command: 'help', platform: 'slack', userId: 'u1', args: []
+      });
+
+      expect(mock.handleCommand).toHaveBeenCalled();
+    });
+
+    it('should log warning for failed commands', async () => {
+      const mock = createMockPlatformInterface('slack');
+      (mock.handleCommand as jest.Mock).mockResolvedValue({
+        success: false, message: 'fail', error: 'SOME_ERROR'
+      });
+      hybridManager.registerPlatformInterface('slack', mock);
+
+      const result = await hybridManager.processCommand({
+        command: 'subscribe', platform: 'slack', userId: 'u1', args: []
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('token management', () => {
+    it('should generate and validate tokens', async () => {
+      const token = await hybridManager.generateUserToken('telegram', 'user123');
+      expect(token.token).toBeTruthy();
+      expect(token.platform).toBe('telegram');
+      expect(token.userId).toBe('user123');
+
+      const validated = await hybridManager.validateToken(token.token);
+      expect(validated).not.toBeNull();
+      expect(validated!.userId).toBe('user123');
+    });
+
+    it('should return null for invalid token', async () => {
+      const validated = await hybridManager.validateToken('nonexistent');
+      expect(validated).toBeNull();
+    });
+
+    it('should revoke tokens', async () => {
+      const token = await hybridManager.generateUserToken('slack', 'user456');
+      const revoked = await hybridManager.revokeToken(token.token);
+      expect(revoked).toBe(true);
+
+      const validated = await hybridManager.validateToken(token.token);
+      expect(validated).toBeNull();
+    });
+
+    it('should return false when revoking nonexistent token', async () => {
+      const revoked = await hybridManager.revokeToken('nonexistent');
+      expect(revoked).toBe(false);
+    });
+
+    it('should reject expired tokens', async () => {
+      const token = await hybridManager.generateUserToken('telegram', 'user1');
+      // Manually expire the token by modifying internal state
+      const validated = await hybridManager.validateToken(token.token);
+      expect(validated).not.toBeNull();
+    });
+  });
+
+  describe('syncSubscriptions', () => {
+    it('should complete without error', async () => {
+      hybridManager.registerPlatformInterface('telegram', createMockPlatformInterface('telegram'));
+      await expect(hybridManager.syncSubscriptions()).resolves.not.toThrow();
+    });
+
+    it('should handle errors in platform sync', async () => {
+      hybridManager.registerPlatformInterface('telegram', createMockPlatformInterface('telegram'));
+      await hybridManager.syncSubscriptions();
+      // Should not throw
+    });
+  });
+
+  describe('getPlatformStats', () => {
+    it('should return stats with platform breakdown', async () => {
+      hybridManager.registerPlatformInterface('telegram', createMockPlatformInterface('telegram'));
+
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'u1',
+        targetRegions: ['L1100000'], warningTypes: ['H'],
+        enabled: true, displayName: 'Test'
+      });
+
+      const stats = await hybridManager.getPlatformStats();
+      expect(stats.overall).toBeDefined();
+      expect(stats.platforms.telegram).toBeDefined();
+      expect(stats.platforms.telegram.totalSubscriptions).toBe(1);
+      expect(stats.interfaces.registered).toContain('telegram');
+    });
+
+    it('should include web interface status', async () => {
+      const stats = await hybridManager.getPlatformStats();
+      expect(stats.interfaces.webEnabled).toBe(false);
+
+      hybridManager.registerWebInterface({} as any);
+      const stats2 = await hybridManager.getPlatformStats();
+      expect(stats2.interfaces.webEnabled).toBe(true);
+    });
+
+    it('should break down regions and warning types', async () => {
+      hybridManager.registerPlatformInterface('slack', createMockPlatformInterface('slack'));
+
+      subManager.addSubscription({
+        platform: 'slack', userId: 'u1',
+        targetRegions: ['L1100000', 'L1150000'], warningTypes: ['H', 'R'],
+        enabled: true, displayName: 'Test'
+      });
+      subManager.addSubscription({
+        platform: 'slack', userId: 'u2',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test2'
+      });
+
+      const stats = await hybridManager.getPlatformStats();
+      expect(stats.platforms.slack.regions['L1100000']).toBe(2);
+      expect(stats.platforms.slack.warningTypes['H']).toBe(1);
+      expect(stats.platforms.slack.warningTypes['ALL']).toBe(1);
+    });
+  });
+
+  describe('getSubscriptionManager', () => {
+    it('should return the subscription manager', () => {
+      expect(hybridManager.getSubscriptionManager()).toBe(subManager);
+    });
+  });
+
+  describe('getHelpMessage', () => {
+    it('should return help from the platform interface', async () => {
+      const mock = createMockPlatformInterface('telegram');
+      hybridManager.registerPlatformInterface('telegram', mock);
+
+      const help = await hybridManager.getHelpMessage('telegram');
+      expect(help).toBe('telegram help message');
+    });
+
+    it('should return error message for unknown platform', async () => {
+      const help = await hybridManager.getHelpMessage('unknown');
+      expect(help).toContain('지원하지 않는 플랫폼');
+    });
+  });
+});

--- a/src/__tests__/services/subscriptions/HybridSubscriptionManager.test.ts
+++ b/src/__tests__/services/subscriptions/HybridSubscriptionManager.test.ts
@@ -159,9 +159,10 @@ describe('HybridSubscriptionManager', () => {
 
     it('should reject expired tokens', async () => {
       const token = await hybridManager.generateUserToken('telegram', 'user1');
-      // Manually expire the token by modifying internal state
+      // 토큰 내부의 expiresAt을 과거로 수정하여 만료 시뮬레이션
+      token.expiresAt = new Date(Date.now() - 1000);
       const validated = await hybridManager.validateToken(token.token);
-      expect(validated).not.toBeNull();
+      expect(validated).toBeNull();
     });
   });
 

--- a/src/__tests__/services/subscriptions/HybridSubscriptionManager.test.ts
+++ b/src/__tests__/services/subscriptions/HybridSubscriptionManager.test.ts
@@ -1,6 +1,6 @@
 import { HybridSubscriptionManager } from '../../../services/subscriptions/HybridSubscriptionManager';
 import { SubscriptionManager } from '../../../services/notifications/SubscriptionManager';
-import { PlatformSubscriptionInterface, SubscriptionCommandParams, UserAuthToken } from '../../../services/subscriptions/interfaces';
+import { PlatformSubscriptionInterface, SubscriptionCommandParams } from '../../../services/subscriptions/interfaces';
 
 jest.mock('../../../utils/logger', () => ({
   logger: {

--- a/src/__tests__/services/subscriptions/SlackInteractiveInterface.test.ts
+++ b/src/__tests__/services/subscriptions/SlackInteractiveInterface.test.ts
@@ -1,0 +1,278 @@
+import { SlackInteractiveInterface } from '../../../services/subscriptions/SlackInteractiveInterface';
+import { SubscriptionManager } from '../../../services/notifications/SubscriptionManager';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+describe('SlackInteractiveInterface', () => {
+  let subManager: SubscriptionManager;
+  let slackInterface: SlackInteractiveInterface;
+  let mockWebInterface: any;
+
+  beforeEach(() => {
+    subManager = new SubscriptionManager();
+    mockWebInterface = {
+      generateAccessToken: jest.fn().mockResolvedValue({
+        token: 'slack-web-token-123',
+        platform: 'slack', userId: 'U123',
+        expiresAt: new Date(Date.now() + 86400000), createdAt: new Date()
+      })
+    };
+    slackInterface = new SlackInteractiveInterface(
+      subManager, 'https://hooks.slack.com/test', mockWebInterface
+    );
+  });
+
+  describe('constructor', () => {
+    it('should initialize with platform name slack', () => {
+      expect(slackInterface.platformName).toBe('slack');
+    });
+
+    it('should work without optional params', () => {
+      const si = new SlackInteractiveInterface(subManager);
+      expect(si.platformName).toBe('slack');
+    });
+  });
+
+  describe('setWebInterface', () => {
+    it('should set the web interface', () => {
+      const si = new SlackInteractiveInterface(subManager);
+      si.setWebInterface(mockWebInterface);
+      // No throw
+    });
+  });
+
+  describe('handleCommand', () => {
+    it('should handle help command', async () => {
+      const result = await slackInterface.handleCommand({
+        command: 'help', platform: 'slack', userId: 'U123', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('구독');
+    });
+
+    it('should handle status command', async () => {
+      subManager.addSubscription({
+        platform: 'slack', userId: 'U123',
+        targetRegions: ['L1100000'], warningTypes: ['H'],
+        enabled: true, displayName: 'TestUser'
+      });
+
+      const result = await slackInterface.handleCommand({
+        command: 'status', platform: 'slack', userId: 'U123', args: []
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle settings command', async () => {
+      const result = await slackInterface.handleCommand({
+        command: 'settings', platform: 'slack', userId: 'U123', args: []
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should return USE_INTERACTIVE_BUTTONS for subscribe', async () => {
+      const result = await slackInterface.handleCommand({
+        command: 'subscribe', platform: 'slack', userId: 'U123', args: ['seoul']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('USE_INTERACTIVE_BUTTONS');
+    });
+
+    it('should return USE_INTERACTIVE_BUTTONS for unsubscribe', async () => {
+      const result = await slackInterface.handleCommand({
+        command: 'unsubscribe', platform: 'slack', userId: 'U123', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('USE_INTERACTIVE_BUTTONS');
+    });
+
+    it('should return USE_INTERACTIVE_BUTTONS for list', async () => {
+      const result = await slackInterface.handleCommand({
+        command: 'list', platform: 'slack', userId: 'U123', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('USE_INTERACTIVE_BUTTONS');
+    });
+  });
+
+  describe('createSubscriptionMessage', () => {
+    it('should create message for new user', async () => {
+      const message = await slackInterface.createSubscriptionMessage('U456');
+      expect(message).toBeDefined();
+      expect(message.blocks || message.text).toBeTruthy();
+    });
+
+    it('should create message for existing user', async () => {
+      subManager.addSubscription({
+        platform: 'slack', userId: 'U123',
+        targetRegions: ['L1100000'], warningTypes: ['H'],
+        enabled: true, displayName: 'Test'
+      });
+
+      const subscription = subManager.getUserSubscription('slack', 'U123');
+      const message = await slackInterface.createSubscriptionMessage('U123', subscription!);
+      expect(message).toBeDefined();
+    });
+  });
+
+  describe('handleButtonAction', () => {
+    it('should handle region selection action', async () => {
+      const payload = {
+        type: 'interactive_message',
+        user: { id: 'U123', name: 'test' },
+        channel: { id: 'C123' },
+        actions: [{ name: 'select_regions', type: 'button', value: 'L1100000' }],
+        callback_id: 'subscription_manage',
+        team: { id: 'T123', domain: 'test' },
+        original_message: {},
+        response_url: 'https://hooks.slack.com/response',
+        trigger_id: 'trig123'
+      };
+
+      const result = await slackInterface.handleButtonAction(payload);
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle warning selection action', async () => {
+      subManager.addSubscription({
+        platform: 'slack', userId: 'U123',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const payload = {
+        type: 'interactive_message',
+        user: { id: 'U123' },
+        channel: { id: 'C123' },
+        actions: [{ name: 'select_warnings', type: 'button', value: 'H' }],
+        callback_id: 'subscription_manage',
+        team: { id: 'T123', domain: 'test' },
+        original_message: {},
+        response_url: 'https://hooks.slack.com/response',
+        trigger_id: 'trig123'
+      };
+
+      const result = await slackInterface.handleButtonAction(payload);
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle view_settings action', async () => {
+      const payload = {
+        type: 'interactive_message',
+        user: { id: 'U123' },
+        channel: { id: 'C123' },
+        actions: [{ name: 'view_settings', type: 'button', value: 'view' }],
+        callback_id: 'subscription_manage',
+        team: { id: 'T123', domain: 'test' },
+        original_message: {},
+        response_url: 'https://hooks.slack.com/response',
+        trigger_id: 'trig123'
+      };
+
+      const result = await slackInterface.handleButtonAction(payload);
+      expect(result).toBeDefined();
+    });
+
+    it('should handle unsubscribe_all action', async () => {
+      subManager.addSubscription({
+        platform: 'slack', userId: 'U123',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const payload = {
+        type: 'interactive_message',
+        user: { id: 'U123' },
+        channel: { id: 'C123' },
+        actions: [{ name: 'unsubscribe_all', type: 'button', value: 'confirm' }],
+        callback_id: 'subscription_manage',
+        team: { id: 'T123', domain: 'test' },
+        original_message: {},
+        response_url: 'https://hooks.slack.com/response',
+        trigger_id: 'trig123'
+      };
+
+      const result = await slackInterface.handleButtonAction(payload);
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle unknown action', async () => {
+      const payload = {
+        type: 'interactive_message',
+        user: { id: 'U123' },
+        channel: { id: 'C123' },
+        actions: [{ name: 'unknown_action', type: 'button', value: 'xxx' }],
+        callback_id: 'subscription_manage',
+        team: { id: 'T123', domain: 'test' },
+        original_message: {},
+        response_url: 'https://hooks.slack.com/response',
+        trigger_id: 'trig123'
+      };
+
+      const result = await slackInterface.handleButtonAction(payload);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('createConfirmationMessage', () => {
+    it('should create success confirmation', () => {
+      const message = slackInterface.createConfirmationMessage({
+        success: true, message: '구독 추가 완료'
+      });
+      expect(message).toBeDefined();
+      expect(message.text || (message as any).blocks).toBeTruthy();
+    });
+
+    it('should create failure confirmation', () => {
+      const message = slackInterface.createConfirmationMessage({
+        success: false, message: '실패', error: 'ERR'
+      });
+      expect(message).toBeDefined();
+    });
+  });
+
+  describe('enhanceAlertMessageWithSubscription', () => {
+    it('should enhance alert message with subscription button', () => {
+      const original = { text: '기상특보 발령', attachments: [] };
+      const enhanced = slackInterface.enhanceAlertMessageWithSubscription(original, 'U123');
+      expect(enhanced).toBeDefined();
+    });
+
+    it('should work without userId', () => {
+      const original = { text: '기상특보 발령' };
+      const enhanced = slackInterface.enhanceAlertMessageWithSubscription(original);
+      expect(enhanced).toBeDefined();
+    });
+  });
+
+  describe('generateAuthToken', () => {
+    it('should generate auth token via web interface', async () => {
+      const token = await slackInterface.generateAuthToken('U123');
+      expect(token.platform).toBe('slack');
+      expect(token.userId).toBe('U123');
+      expect(token.token).toBeTruthy();
+    });
+  });
+
+  describe('notifySubscriptionChange', () => {
+    it('should not throw', async () => {
+      await expect(
+        slackInterface.notifySubscriptionChange('U123', 'test change')
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('getHelpMessage', () => {
+    it('should return help with subscription info', () => {
+      const help = slackInterface.getHelpMessage();
+      expect(help).toContain('구독');
+    });
+  });
+});

--- a/src/__tests__/services/subscriptions/TelegramSubscriptionInterface.test.ts
+++ b/src/__tests__/services/subscriptions/TelegramSubscriptionInterface.test.ts
@@ -14,12 +14,21 @@ jest.mock('../../../utils/logger', () => ({
 describe('TelegramSubscriptionInterface', () => {
   let subscriptionManager: SubscriptionManager;
   let telegramInterface: TelegramSubscriptionInterface;
+  let mockWebInterface: any;
 
   beforeEach(() => {
     subscriptionManager = new SubscriptionManager();
+    mockWebInterface = {
+      generateAccessToken: jest.fn().mockResolvedValue({
+        token: 'tg-web-token-abc123',
+        platform: 'telegram', userId: 'user123',
+        expiresAt: new Date(Date.now() + 86400000), createdAt: new Date()
+      })
+    };
     telegramInterface = new TelegramSubscriptionInterface(
       subscriptionManager,
-      'test-bot-token'
+      'test-bot-token',
+      mockWebInterface
     );
   });
 
@@ -70,6 +79,365 @@ describe('TelegramSubscriptionInterface', () => {
 
       // Should escape the special characters (? and & are not special in Telegram Markdown)
       expect(escapedText).toBe('URL: https://example\\.com/path?token\\=ABC\\_123&param\\=value\\[0\\]');
+    });
+  });
+
+  describe('constructor', () => {
+    it('should initialize with platform name telegram', () => {
+      expect(telegramInterface.platformName).toBe('telegram');
+    });
+
+    it('should work without optional params', () => {
+      const t = new TelegramSubscriptionInterface(subscriptionManager);
+      expect(t.platformName).toBe('telegram');
+    });
+
+    it('should accept custom dashboard URL', () => {
+      const t = new TelegramSubscriptionInterface(subscriptionManager, undefined, undefined, 'https://custom.url');
+      expect(t.platformName).toBe('telegram');
+    });
+  });
+
+  describe('setWebInterface', () => {
+    it('should set the web interface', () => {
+      const t = new TelegramSubscriptionInterface(subscriptionManager);
+      t.setWebInterface(mockWebInterface);
+    });
+  });
+
+  describe('handleCommand - subscribe', () => {
+    it('should subscribe to a region', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: ['seoul']
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('구독이 추가');
+    });
+
+    it('should subscribe with warning type', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: ['seoul', 'heat']
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('폭염');
+    });
+
+    it('should subscribe with "all" warning type', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: ['seoul', 'all']
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('모든 특보');
+    });
+
+    it('should fail without region arg (caught by validateCommand)', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_COMMAND_FORMAT');
+    });
+
+    it('should fail with invalid region', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: ['mars']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_REGION');
+    });
+
+    it('should fail with invalid warning type', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: ['seoul', 'invalidtype']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_WARNING_TYPE');
+    });
+
+    it('should merge with existing subscription regions', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      await telegramInterface.handleCommand({
+        command: 'subscribe', platform: 'telegram', userId: 'user1', args: ['busan']
+      });
+
+      const sub = subscriptionManager.getUserSubscription('telegram', 'user1');
+      expect(sub!.targetRegions).toContain('L1100000');
+      expect(sub!.targetRegions).toContain('L1150000');
+    });
+  });
+
+  describe('handleCommand - unsubscribe', () => {
+    it('should fail when no subscription exists', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'unsubscribe', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('NO_SUBSCRIPTION');
+    });
+
+    it('should remove all subscriptions without args', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'unsubscribe', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(subscriptionManager.getUserSubscription('telegram', 'user1')).toBeUndefined();
+    });
+
+    it('should remove specific region', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000', 'L1150000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'unsubscribe', platform: 'telegram', userId: 'user1', args: ['seoul']
+      });
+      expect(result.success).toBe(true);
+
+      const sub = subscriptionManager.getUserSubscription('telegram', 'user1');
+      expect(sub!.targetRegions).not.toContain('L1100000');
+      expect(sub!.targetRegions).toContain('L1150000');
+    });
+
+    it('should remove subscription when last region removed', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'unsubscribe', platform: 'telegram', userId: 'user1', args: ['seoul']
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('완전히 제거');
+    });
+
+    it('should fail with invalid region', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'unsubscribe', platform: 'telegram', userId: 'user1', args: ['mars']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_REGION');
+    });
+
+    it('should fail when region not subscribed', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'unsubscribe', platform: 'telegram', userId: 'user1', args: ['busan']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('REGION_NOT_SUBSCRIBED');
+    });
+  });
+
+  describe('handleCommand - quiet', () => {
+    it('should fail without time arguments (caught by validateCommand)', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'quiet', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_COMMAND_FORMAT');
+    });
+
+    it('should fail with invalid time format (caught by validateCommand)', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'quiet', platform: 'telegram', userId: 'user1', args: ['25:00', '08:00']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_COMMAND_FORMAT');
+    });
+
+    it('should fail when no subscription exists', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'quiet', platform: 'telegram', userId: 'user1', args: ['22:00', '08:00']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('NO_SUBSCRIPTION');
+    });
+
+    it('should set quiet hours successfully', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'quiet', platform: 'telegram', userId: 'user1', args: ['22:00', '08:00']
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('22:00');
+    });
+  });
+
+  describe('handleCommand - status', () => {
+    it('should show system status', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'status', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('구독 시스템 현황');
+    });
+
+    it('should show subscription status when subscribed', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'status', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('구독 중');
+    });
+  });
+
+  describe('handleCommand - help', () => {
+    it('should return help message', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'help', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('subscribe');
+    });
+  });
+
+  describe('handleCommand - unknown/invalid', () => {
+    it('should return error for unknown command (caught by validateCommand)', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'unknown' as any, platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_COMMAND_FORMAT');
+    });
+
+    it('should return error for invalid command format', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: '' as any, platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_COMMAND_FORMAT');
+    });
+  });
+
+  describe('handleCommand - list', () => {
+    it('should show no subscription message', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'list', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('구독 중인 알림이 없습니다');
+    });
+
+    it('should handle settings as alias for list', async () => {
+      const result = await telegramInterface.handleCommand({
+        command: 'settings', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('generateAuthToken', () => {
+    it('should return a valid auth token', async () => {
+      const token = await telegramInterface.generateAuthToken('user123');
+      expect(token.platform).toBe('telegram');
+      expect(token.userId).toBe('user123');
+      expect(token.token).toMatch(/^TG_/);
+      expect(token.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    });
+  });
+
+  describe('notifySubscriptionChange', () => {
+    it('should not throw without bot token', async () => {
+      const t = new TelegramSubscriptionInterface(subscriptionManager);
+      await expect(
+        t.notifySubscriptionChange('user1', 'test change')
+      ).resolves.not.toThrow();
+    });
+
+    it('should not throw with bot token', async () => {
+      await expect(
+        telegramInterface.notifySubscriptionChange('user1', 'test change')
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('getHelpMessage', () => {
+    it('should return help text', () => {
+      const help = telegramInterface.getHelpMessage();
+      expect(help).toContain('subscribe');
+    });
+  });
+
+  describe('web token generation', () => {
+    it('should use web interface for token when available', async () => {
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'list', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(mockWebInterface.generateAccessToken).toHaveBeenCalled();
+    });
+
+    it('should fallback to auth token when web interface fails', async () => {
+      mockWebInterface.generateAccessToken.mockRejectedValue(new Error('DB error'));
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await telegramInterface.handleCommand({
+        command: 'list', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('TG\\_');
+    });
+
+    it('should use fallback token when no web interface', async () => {
+      const t = new TelegramSubscriptionInterface(subscriptionManager);
+      subscriptionManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await t.handleCommand({
+        command: 'list', platform: 'telegram', userId: 'user1', args: []
+      });
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('TG\\_');
     });
   });
 

--- a/src/__tests__/services/subscriptions/WebSubscriptionInterface.test.ts
+++ b/src/__tests__/services/subscriptions/WebSubscriptionInterface.test.ts
@@ -1,0 +1,336 @@
+import { WebSubscriptionInterface } from '../../../services/subscriptions/WebSubscriptionInterface';
+import { SubscriptionManager } from '../../../services/notifications/SubscriptionManager';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+function createMockTokenService() {
+  return {
+    validateToken: jest.fn().mockResolvedValue({
+      token: 'valid-token', platform: 'telegram', userId: 'user1',
+      displayName: 'Test User', expiresAt: new Date(Date.now() + 86400000),
+      createdAt: new Date()
+    }),
+    generateToken: jest.fn().mockResolvedValue({
+      token: 'new-generated-token', platform: 'telegram', userId: 'user1',
+      expiresAt: new Date(Date.now() + 86400000), createdAt: new Date()
+    }),
+    revokeToken: jest.fn().mockResolvedValue(true)
+  };
+}
+
+describe('WebSubscriptionInterface', () => {
+  let subManager: SubscriptionManager;
+  let mockTokenService: ReturnType<typeof createMockTokenService>;
+  let webInterface: WebSubscriptionInterface;
+
+  beforeEach(() => {
+    subManager = new SubscriptionManager();
+    mockTokenService = createMockTokenService();
+    webInterface = new WebSubscriptionInterface(subManager, mockTokenService as any);
+  });
+
+  describe('authenticateWithToken', () => {
+    it('should return existing subscription for valid token', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: ['H'],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await webInterface.authenticateWithToken('valid-token');
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe('telegram');
+      expect(result!.targetRegions).toContain('L1100000');
+    });
+
+    it('should return default subscription for new user', async () => {
+      const result = await webInterface.authenticateWithToken('valid-token');
+      expect(result).not.toBeNull();
+      expect(result!.id).toMatch(/^temp_/);
+      expect(result!.enabled).toBe(false);
+      expect(result!.targetRegions).toEqual([]);
+    });
+
+    it('should return null for invalid token', async () => {
+      mockTokenService.validateToken.mockResolvedValue(null);
+      const result = await webInterface.authenticateWithToken('bad-token');
+      expect(result).toBeNull();
+    });
+
+    it('should return null on validation error', async () => {
+      mockTokenService.validateToken.mockRejectedValue(new Error('DB error'));
+      const result = await webInterface.authenticateWithToken('token');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateSubscription', () => {
+    it('should update subscription with valid token', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        targetRegions: ['L1100000'],
+        warningTypes: ['H'],
+        enabled: true
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+    });
+
+    it('should fail with expired token', async () => {
+      mockTokenService.validateToken.mockResolvedValue(null);
+      const result = await webInterface.updateSubscription('bad-token', {
+        targetRegions: ['L1100000']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('TOKEN_EXPIRED');
+    });
+
+    it('should merge preferences with existing subscription', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test',
+        preferences: { minLevel: '2' }
+      });
+
+      const result = await webInterface.updateSubscription('valid-token', {
+        preferences: { quietHours: { start: '22:00', end: '08:00' } }
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should remove quietHours when explicitly set to null', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test',
+        preferences: { quietHours: { start: '22:00', end: '08:00' } }
+      });
+
+      const result = await webInterface.updateSubscription('valid-token', {
+        preferences: { quietHours: null }
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid region code', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        targetRegions: ['INVALID_CODE']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_REGION_CODE');
+    });
+
+    it('should reject invalid warning type', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        warningTypes: ['X']
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_WARNING_TYPE');
+    });
+
+    it('should reject invalid time format in quiet hours', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        preferences: { quietHours: { start: '25:00', end: '08:00' } }
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_TIME_FORMAT');
+    });
+
+    it('should reject invalid min level', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        preferences: { minLevel: '5' }
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_WARNING_LEVEL');
+    });
+
+    it('should accept valid region codes', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        targetRegions: ['L1100000', 'L1150000']
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept empty region (nationwide)', async () => {
+      const result = await webInterface.updateSubscription('valid-token', {
+        targetRegions: ['']
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('getUserSubscriptions', () => {
+    it('should return subscriptions for valid token', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const subs = await webInterface.getUserSubscriptions('valid-token');
+      expect(subs).toHaveLength(1);
+    });
+
+    it('should return empty for invalid token', async () => {
+      mockTokenService.validateToken.mockResolvedValue(null);
+      const subs = await webInterface.getUserSubscriptions('bad-token');
+      expect(subs).toEqual([]);
+    });
+
+    it('should return empty for user without subscription', async () => {
+      const subs = await webInterface.getUserSubscriptions('valid-token');
+      expect(subs).toEqual([]);
+    });
+  });
+
+  describe('getSubscriptionStats', () => {
+    it('should return stats for valid token', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: ['H'],
+        enabled: true, displayName: 'Test'
+      });
+
+      const stats = await webInterface.getSubscriptionStats('valid-token');
+      expect(stats).not.toBeNull();
+      expect(stats!.overall).toBeDefined();
+      expect(stats!.user).toBeDefined();
+      expect(stats!.metadata).toBeDefined();
+    });
+
+    it('should return null for invalid token', async () => {
+      mockTokenService.validateToken.mockResolvedValue(null);
+      const stats = await webInterface.getSubscriptionStats('bad-token');
+      expect(stats).toBeNull();
+    });
+
+    it('should show user without subscription', async () => {
+      const stats = await webInterface.getSubscriptionStats('valid-token');
+      expect(stats).not.toBeNull();
+      expect((stats!.user as any).hasSubscription).toBe(false);
+    });
+  });
+
+  describe('getEnhancedSubscriptionInfo', () => {
+    it('should return enhanced info with region names', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: ['H'],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await webInterface.getEnhancedSubscriptionInfo('valid-token');
+      expect(result.success).toBe(true);
+      expect(result.data!.regionNames).toContain('서울특별시');
+      expect(result.data!.warningTypeNames).toContain('폭염');
+      expect(result.data!.platformDisplayName).toBe('Telegram');
+    });
+
+    it('should return default subscription for new user', async () => {
+      const result = await webInterface.getEnhancedSubscriptionInfo('valid-token');
+      expect(result.success).toBe(true);
+      expect(result.data!.regionNames).toEqual(['전국']);
+    });
+
+    it('should fail for invalid token', async () => {
+      mockTokenService.validateToken.mockResolvedValue(null);
+      const result = await webInterface.getEnhancedSubscriptionInfo('bad-token');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('deleteSubscription', () => {
+    it('should delete existing subscription', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      const result = await webInterface.deleteSubscription('valid-token');
+      expect(result.success).toBe(true);
+      expect(subManager.getUserSubscription('telegram', 'user1')).toBeUndefined();
+    });
+
+    it('should fail for invalid token', async () => {
+      mockTokenService.validateToken.mockResolvedValue(null);
+      const result = await webInterface.deleteSubscription('bad-token');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('TOKEN_EXPIRED');
+    });
+
+    it('should fail when no subscription exists', async () => {
+      const result = await webInterface.deleteSubscription('valid-token');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('NO_SUBSCRIPTION');
+    });
+
+    it('should revoke token after successful delete', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      await webInterface.deleteSubscription('valid-token');
+      expect(mockTokenService.revokeToken).toHaveBeenCalledWith('valid-token');
+    });
+
+    it('should handle token revocation failure gracefully', async () => {
+      subManager.addSubscription({
+        platform: 'telegram', userId: 'user1',
+        targetRegions: ['L1100000'], warningTypes: [],
+        enabled: true, displayName: 'Test'
+      });
+
+      mockTokenService.revokeToken.mockResolvedValue(false);
+      const result = await webInterface.deleteSubscription('valid-token');
+      expect(result.success).toBe(true); // Subscription still deleted
+    });
+  });
+
+  describe('generateAccessToken', () => {
+    it('should delegate to token service', async () => {
+      const tokenInfo = await webInterface.generateAccessToken('telegram', 'user1', 'Test');
+      expect(mockTokenService.generateToken).toHaveBeenCalledWith({
+        platform: 'telegram', userId: 'user1', displayName: 'Test',
+        expiresInHours: 720
+      });
+      expect(tokenInfo.token).toBe('new-generated-token');
+    });
+  });
+
+  describe('registerToken (deprecated)', () => {
+    it('should delegate to token service', async () => {
+      const authToken = {
+        token: 'old-token', platform: 'slack', userId: 'U1',
+        expiresAt: new Date(Date.now() + 86400000), createdAt: new Date()
+      };
+      await webInterface.registerToken(authToken);
+      expect(mockTokenService.generateToken).toHaveBeenCalled();
+    });
+  });
+
+  describe('getAvailableRegions', () => {
+    it('should return all regions', () => {
+      const regions = webInterface.getAvailableRegions();
+      expect(regions.length).toBeGreaterThan(10);
+      expect(regions.find(r => r.name === '서울특별시')).toBeDefined();
+    });
+  });
+
+  describe('getAvailableWarningTypes', () => {
+    it('should return all warning types', () => {
+      const types = webInterface.getAvailableWarningTypes();
+      expect(types.length).toBeGreaterThan(10);
+      expect(types.find(t => t.name === '폭염')).toBeDefined();
+    });
+  });
+});

--- a/src/__tests__/services/weatherService.test.ts
+++ b/src/__tests__/services/weatherService.test.ts
@@ -788,4 +788,217 @@ L1020110, 202101010000, 202312312359, A, L1020000, 서울강북, 서울특별시
     });
   });
 
+  describe('getCacheStatus', () => {
+    it('캐시 상태를 반환한다', () => {
+      const status = weatherService.getCacheStatus();
+      expect(status).toHaveProperty('count');
+      expect(status).toHaveProperty('lastUpdated');
+      expect(status).toHaveProperty('isInitialized');
+      expect(status).toHaveProperty('lastCheckTime');
+      expect(status.isInitialized).toBe(false);
+    });
+  });
+
+  describe('clearAlertCache', () => {
+    it('캐시를 초기화한다', () => {
+      weatherService.clearAlertCache();
+      const status = weatherService.getCacheStatus();
+      expect(status.count).toBe(0);
+      expect(status.isInitialized).toBe(false);
+    });
+  });
+
+  describe('getCachedAlerts', () => {
+    it('캐시된 특보를 반환한다', () => {
+      const alerts = weatherService.getCachedAlerts();
+      expect(Array.isArray(alerts)).toBe(true);
+    });
+  });
+
+  describe('getWeatherForecast', () => {
+    it('격자 좌표를 찾을 수 없으면 null을 반환한다', async () => {
+      const result = await weatherService.getWeatherForecast('UNKNOWN_ID');
+      expect(result).toBeNull();
+    });
+
+    it('API 호출 실패 시 null을 반환한다', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+      const result = await weatherService.getWeatherForecast('L1100000');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('selectNearestTimeSlice (private)', () => {
+    it('가장 가까운 시간대를 선택한다', () => {
+      const items = [
+        { fcstDate: '20260101', fcstTime: '0900', category: 'T1H', fcstValue: '5' },
+        { fcstDate: '20260101', fcstTime: '1000', category: 'T1H', fcstValue: '7' },
+        { fcstDate: '20260101', fcstTime: '1100', category: 'T1H', fcstValue: '9' }
+      ];
+      const now = new Date('2026-01-01T01:30:00Z'); // KST 10:30
+      const result = (weatherService as any).selectNearestTimeSlice(items, now);
+      expect(result.items).toBeDefined();
+    });
+
+    it('referenceTimeKey로 가장 가까운 시간대를 선택한다', () => {
+      const items = [
+        { fcstDate: '20260101', fcstTime: '0900', category: 'T3H', fcstValue: '5' },
+        { fcstDate: '20260101', fcstTime: '1200', category: 'T3H', fcstValue: '10' },
+        { fcstDate: '20260101', fcstTime: '1500', category: 'T3H', fcstValue: '12' }
+      ];
+      const now = new Date('2026-01-01T01:00:00Z');
+      const result = (weatherService as any).selectNearestTimeSlice(items, now, '202601011000');
+      expect(result.items).toBeDefined();
+    });
+  });
+
+  describe('parseForecastTime (private)', () => {
+    it('유효한 시간 문자열을 Date로 변환한다', () => {
+      const result = (weatherService as any).parseForecastTime('202601011200');
+      expect(result).toBeInstanceOf(Date);
+      // KST 12:00 → UTC 03:00
+      expect(result.getUTCHours()).toBe(3);
+    });
+
+    it('짧은 문자열은 현재 시간을 반환한다', () => {
+      const before = Date.now();
+      const result = (weatherService as any).parseForecastTime('2026');
+      expect(result).toBeInstanceOf(Date);
+      // 현재 시간 근처여야 함
+      expect(result.getTime()).toBeGreaterThanOrEqual(before - 60000);
+    });
+
+    it('빈 문자열은 현재 시간을 반환한다', () => {
+      const result = (weatherService as any).parseForecastTime('');
+      expect(result).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('calculateFeelsLike (private)', () => {
+    it('10도 이하 + 풍속 있으면 Windchill 계산', () => {
+      const result = (weatherService as any).calculateFeelsLike(5, 5);
+      expect(result).toBeLessThan(5);
+    });
+
+    it('27도 이상 + 습도 40% 이상이면 Heat Index 계산', () => {
+      const result = (weatherService as any).calculateFeelsLike(35, 1, 70);
+      expect(result).toBeGreaterThan(35);
+    });
+
+    it('중간 온도에서는 실제 기온 반환', () => {
+      const result = (weatherService as any).calculateFeelsLike(20, 3);
+      expect(result).toBe(20);
+    });
+
+    it('27도 이상이지만 습도가 낮으면 실제 기온 반환', () => {
+      const result = (weatherService as any).calculateFeelsLike(30, 1, 30);
+      expect(result).toBe(30);
+    });
+
+    it('27도 이상 + 습도 없으면 실제 기온 반환', () => {
+      const result = (weatherService as any).calculateFeelsLike(30, 1);
+      expect(result).toBe(30);
+    });
+  });
+
+  describe('parseNumber (private)', () => {
+    it('유효한 숫자 문자열을 변환한다', () => {
+      expect((weatherService as any).parseNumber('123')).toBe(123);
+      expect((weatherService as any).parseNumber('12.5')).toBe(12.5);
+    });
+
+    it('빈 문자열은 undefined를 반환한다', () => {
+      expect((weatherService as any).parseNumber('')).toBeUndefined();
+    });
+
+    it('undefined는 undefined를 반환한다', () => {
+      expect((weatherService as any).parseNumber(undefined)).toBeUndefined();
+    });
+
+    it('유효하지 않은 문자열은 undefined를 반환한다', () => {
+      expect((weatherService as any).parseNumber('abc')).toBeUndefined();
+    });
+  });
+
+  describe('fetchWithRetry (private)', () => {
+    it('성공 시 바로 반환한다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: 'ok' })
+      });
+
+      const result = await (weatherService as any).fetchWithRetry('https://api.example.com', {}, 1, 5000);
+      expect(result.ok).toBe(true);
+    });
+
+    it('5xx 에러 시 재시도 후 실패한다', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error'
+      });
+
+      await expect(
+        (weatherService as any).fetchWithRetry('https://api.example.com', {}, 2, 100)
+      ).rejects.toThrow();
+    }, 15000);
+
+    it('4xx 에러는 재시도 없이 반환한다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found'
+      });
+
+      const result = await (weatherService as any).fetchWithRetry('https://api.example.com', {}, 3, 5000);
+      expect(result.status).toBe(404);
+      // fetch는 1번만 호출되어야 함
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getUpperRegionName (private)', () => {
+    it('알려진 지역 코드의 이름을 반환한다', () => {
+      const result = (weatherService as any).getUpperRegionName('L1100000');
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('매핑되지 않은 지역 코드는 상위 지역을 재귀 탐색한다', () => {
+      const result = (weatherService as any).getUpperRegionName('L9999999');
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('매핑되지 않은 해상 지역 코드도 처리한다', () => {
+      const result = (weatherService as any).getUpperRegionName('S9999999');
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('최상위 레벨에 도달하면 기타를 반환한다', () => {
+      const result = (weatherService as any).getUpperRegionName('X0000000');
+      expect(result).toBe('기타');
+    });
+
+    it('빈 문자열이면 빈 문자열 반환', () => {
+      const result = (weatherService as any).getUpperRegionName('');
+      expect(result).toBe('');
+    });
+
+    it('8자리가 아니면 빈 문자열 반환', () => {
+      const result = (weatherService as any).getUpperRegionName('L123');
+      expect(result).toBe('');
+    });
+  });
+
+  describe('checkForAlertChanges 에러 처리', () => {
+    it('API 실패 시 빈 배열을 반환한다', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+      const result = await weatherService.checkForAlertChanges();
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
 });

--- a/src/__tests__/services/weatherService.test.ts
+++ b/src/__tests__/services/weatherService.test.ts
@@ -781,7 +781,7 @@ L1020110, 202101010000, 202312312359, A, L1020000, 서울강북, 서울특별시
     });
 
     it('API 호출 실패 시 source를 포함한 실패 결과를 반환한다', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
       const result = await weatherService.getWeatherForecastWithResult('L1100000');
       expect(result.success).toBe(false);
       expect(result.data).toBeNull();
@@ -822,7 +822,7 @@ L1020110, 202101010000, 202312312359, A, L1020000, 서울강북, 서울특별시
     });
 
     it('API 호출 실패 시 null을 반환한다', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
       const result = await weatherService.getWeatherForecast('L1100000');
       expect(result).toBeNull();
     });
@@ -995,7 +995,7 @@ L1020110, 202101010000, 202312312359, A, L1020000, 서울강북, 서울특별시
 
   describe('checkForAlertChanges 에러 처리', () => {
     it('API 실패 시 빈 배열을 반환한다', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
       const result = await weatherService.checkForAlertChanges();
       expect(Array.isArray(result)).toBe(true);
     });


### PR DESCRIPTION
## Summary
- 전체 테스트 커버리지를 **38% → 85%**로 대폭 향상
- 테스트 수: **360개 → 759개** (+399개, +111% 증가)
- 테스트 스위트: **20개 → 23개** (+3개 신규)
- 모든 모듈이 80%+ 커버리지 달성

## 모듈별 커버리지

| 모듈 | 이전 | 현재 |
|------|------|------|
| **전체** | 38% | **85.19%** |
| routes | 38% | **90.69%** |
| services | 40% | **83.57%** |
| notifications | 46% | **83.73%** |
| subscriptions | 8% | **85.98%** |
| types | 100% | **100%** |
| utils | 97% | **97.08%** |

## 신규 테스트 파일 (8개)
- `TokenService.test.ts` - 토큰 생성/검증/삭제/정리/통계 (20개)
- `DatabaseService.test.ts` - CRUD, 동기화, 통계, 매핑 (38개)
- `subscriptionRoutes.test.ts` - REST API 엔드포인트 전체 (32개)
- `CommandParser.test.ts` - 명령어 파싱 및 검증
- `EmailCommandProcessor.test.ts` - 이메일 명령어 처리
- `HybridSubscriptionManager.test.ts` - 하이브리드 구독 관리
- `SlackInteractiveInterface.test.ts` - Slack 인터랙티브 인터페이스
- `WebSubscriptionInterface.test.ts` - 웹 구독 인터페이스

## 기존 테스트 강화 (5개)
- `MultiplatformNotificationService.test.ts` - 에러 처리, 재시도, 구독 기반 알림
- `NotificationFactory.test.ts` - 플랫폼별 생성/검증 전 경로
- `TelegramNotificationService.test.ts` - 웹훅, 포맷팅, 구독자 없음 시나리오
- `TelegramSubscriptionInterface.test.ts` - 27% → 88% (39개 테스트)
- `weatherService.test.ts` - private 메서드, 재시도, 지역명 재귀 탐색

## 설정 변경
- `jest.config.js`: 단위 테스트 불가능한 파일 커버리지 제외
  - `server.ts` (Express 서버 부트스트랩 - 통합 테스트 대상)
  - `examples/` (데모 스크립트)
  - `**/index.ts` (Barrel export)

## Test plan
- [x] `npm test` - 759개 테스트 전체 통과
- [x] `npm run test:coverage` - 85%+ 커버리지 확인
- [x] `npm run build` - 빌드 성공 확인