### PR TITLE
feat: 알림 성공률 추적 시스템 구현 (#121)

### DIFF
--- a/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
+++ b/src/__tests__/services/notifications/MultiplatformNotificationService.test.ts
@@ -747,4 +747,78 @@ describe('MultiplatformNotificationService', () => {
       expect(results[0].platform).toBe('always-fail');
     });
   });
+
+  describe('상세 통계 (NotificationStats 통합)', () => {
+    test('sendAlert 후 상세 통계에 기록됨', async () => {
+      const alert = createMockAlert();
+      await multiService.sendAlert(alert);
+
+      const detailed = multiService.getDetailedStatistics();
+      expect(detailed.length).toBeGreaterThanOrEqual(2);
+
+      const slackStats = detailed.find(s => s.platform === 'slack');
+      expect(slackStats).toBeDefined();
+      expect(slackStats!.totalSent).toBe(1);
+      expect(slackStats!.successCount).toBe(1);
+      expect(slackStats!.successRate).toBe(1.0);
+      expect(slackStats!.averageResponseTimeMs).toBeGreaterThanOrEqual(0);
+      expect(slackStats!.circuitBreakerState).toBe(CircuitState.CLOSED);
+      expect(slackStats!.hourlyStats).toHaveLength(24);
+    });
+
+    test('getDetailedPlatformStats로 개별 플랫폼 조회', async () => {
+      await multiService.sendAlert(createMockAlert());
+
+      const slackStats = multiService.getDetailedPlatformStats('slack');
+      expect(slackStats).toBeDefined();
+      expect(slackStats!.platform).toBe('slack');
+      expect(slackStats!.totalSent).toBe(1);
+    });
+
+    test('존재하지 않는 플랫폼은 undefined', () => {
+      expect(multiService.getDetailedPlatformStats('nonexistent')).toBeUndefined();
+    });
+
+    test('실패 서비스도 통계에 기록됨', async () => {
+      const failService = new MockNotificationService('fail-svc', true);
+      const svc = new MultiplatformNotificationService([failService]);
+      await svc.sendAlert(createMockAlert());
+
+      const stats = svc.getDetailedPlatformStats('fail-svc');
+      expect(stats).toBeDefined();
+      expect(stats!.totalSent).toBe(1);
+      expect(stats!.failureCount).toBe(1);
+      expect(stats!.successRate).toBe(0);
+    });
+
+    test('resetStatistics로 특정 플랫폼 초기화', async () => {
+      await multiService.sendAlert(createMockAlert());
+      multiService.resetStatistics('slack');
+
+      expect(multiService.getDetailedPlatformStats('slack')).toBeUndefined();
+      expect(multiService.getDetailedPlatformStats('telegram')).toBeDefined();
+    });
+
+    test('resetStatistics로 전체 초기화', async () => {
+      await multiService.sendAlert(createMockAlert());
+      multiService.resetStatistics();
+
+      expect(multiService.getDetailedStatistics()).toEqual([]);
+    });
+
+    test('lastSuccessAt이 성공 시 기록됨', async () => {
+      await multiService.sendAlert(createMockAlert());
+
+      const stats = multiService.getDetailedPlatformStats('slack');
+      expect(stats!.lastSuccessAt).toBeInstanceOf(Date);
+    });
+
+    test('응답 시간이 측정됨', async () => {
+      await multiService.sendAlert(createMockAlert());
+
+      const stats = multiService.getDetailedPlatformStats('slack');
+      expect(typeof stats!.averageResponseTimeMs).toBe('number');
+      expect(stats!.averageResponseTimeMs).toBeGreaterThanOrEqual(0);
+    });
+  });
 });

--- a/src/__tests__/services/notifications/NotificationStats.test.ts
+++ b/src/__tests__/services/notifications/NotificationStats.test.ts
@@ -1,0 +1,299 @@
+import { NotificationStats } from '../../../services/notifications/NotificationStats';
+import { CircuitState } from '../../../services/notifications/CircuitBreaker';
+
+describe('NotificationStats', () => {
+  let stats: NotificationStats;
+
+  beforeEach(() => {
+    stats = new NotificationStats();
+  });
+
+  describe('recordResult', () => {
+    it('성공 결과를 기록', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+
+      const result = stats.getStats('slack');
+      expect(result).toBeDefined();
+      expect(result!.totalSent).toBe(1);
+      expect(result!.successCount).toBe(1);
+      expect(result!.failureCount).toBe(0);
+    });
+
+    it('실패 결과를 기록', () => {
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 50 });
+
+      const result = stats.getStats('slack');
+      expect(result!.totalSent).toBe(1);
+      expect(result!.successCount).toBe(0);
+      expect(result!.failureCount).toBe(1);
+    });
+
+    it('여러 플랫폼 결과를 독립적으로 기록', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'telegram', success: false, responseTimeMs: 200 });
+
+      const slack = stats.getStats('slack');
+      const telegram = stats.getStats('telegram');
+      expect(slack!.successCount).toBe(1);
+      expect(telegram!.failureCount).toBe(1);
+    });
+  });
+
+  describe('성공률 계산', () => {
+    it('모든 성공 시 성공률 1.0', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 150 });
+
+      expect(stats.getStats('slack')!.successRate).toBe(1.0);
+    });
+
+    it('모든 실패 시 성공률 0', () => {
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 150 });
+
+      expect(stats.getStats('slack')!.successRate).toBe(0);
+    });
+
+    it('혼합 결과 시 정확한 비율', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 100 });
+
+      expect(stats.getStats('slack')!.successRate).toBeCloseTo(2 / 3);
+    });
+
+    it('데이터 없는 플랫폼은 undefined', () => {
+      expect(stats.getStats('unknown')).toBeUndefined();
+    });
+  });
+
+  describe('평균 응답시간', () => {
+    it('단일 결과의 평균 응답시간', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 200 });
+
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(200);
+    });
+
+    it('다중 결과의 평균 응답시간', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 300 });
+
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(200);
+    });
+
+    it('성공/실패 모두 응답시간에 포함', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 500 });
+
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(300);
+    });
+  });
+
+  describe('마지막 성공/실패 시각', () => {
+    it('성공 시 lastSuccessAt 업데이트', () => {
+      const ts = new Date('2026-01-15T10:00:00Z');
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: ts });
+
+      expect(stats.getStats('slack')!.lastSuccessAt).toEqual(ts);
+      expect(stats.getStats('slack')!.lastFailureAt).toBeNull();
+    });
+
+    it('실패 시 lastFailureAt 업데이트', () => {
+      const ts = new Date('2026-01-15T10:00:00Z');
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 100, timestamp: ts });
+
+      expect(stats.getStats('slack')!.lastFailureAt).toEqual(ts);
+      expect(stats.getStats('slack')!.lastSuccessAt).toBeNull();
+    });
+
+    it('여러 기록 시 마지막 시각 유지', () => {
+      const ts1 = new Date('2026-01-15T10:00:00Z');
+      const ts2 = new Date('2026-01-15T11:00:00Z');
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: ts1 });
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: ts2 });
+
+      expect(stats.getStats('slack')!.lastSuccessAt).toEqual(ts2);
+    });
+  });
+
+  describe('시간대별 통계', () => {
+    it('24시간 전체 슬롯 반환', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+
+      const hourly = stats.getStats('slack')!.hourlyStats;
+      expect(hourly).toHaveLength(24);
+      expect(hourly[0].hour).toBe(0);
+      expect(hourly[23].hour).toBe(23);
+    });
+
+    it('특정 시간대에 기록', () => {
+      const ts10 = new Date('2026-01-15T10:30:00Z');
+      const ts14 = new Date('2026-01-15T14:00:00Z');
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: ts10 });
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 200, timestamp: ts14 });
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: ts10 });
+
+      const hourly = stats.getStats('slack')!.hourlyStats;
+      // hour 10: UTC 기준
+      expect(hourly[10].sent).toBe(2);
+      expect(hourly[10].success).toBe(2);
+      // hour 14: UTC 기준
+      expect(hourly[14].sent).toBe(1);
+      expect(hourly[14].success).toBe(0);
+    });
+
+    it('데이터 없는 시간대는 0', () => {
+      stats.recordResult({
+        platform: 'slack',
+        success: true,
+        responseTimeMs: 100,
+        timestamp: new Date('2026-01-15T05:00:00Z'),
+      });
+
+      const hourly = stats.getStats('slack')!.hourlyStats;
+      expect(hourly[0].sent).toBe(0);
+      expect(hourly[0].success).toBe(0);
+      expect(hourly[5].sent).toBe(1);
+    });
+  });
+
+  describe('CircuitBreaker 상태 포함', () => {
+    it('기본 상태는 CLOSED', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      expect(stats.getStats('slack')!.circuitBreakerState).toBe(CircuitState.CLOSED);
+    });
+
+    it('외부에서 전달한 CircuitBreaker 상태 반영', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+
+      const result = stats.getStats('slack', CircuitState.OPEN);
+      expect(result!.circuitBreakerState).toBe(CircuitState.OPEN);
+    });
+  });
+
+  describe('getAllStats', () => {
+    it('모든 플랫폼 통계 반환', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'telegram', success: false, responseTimeMs: 200 });
+
+      const all = stats.getAllStats();
+      expect(all).toHaveLength(2);
+      expect(all.map(s => s.platform).sort()).toEqual(['slack', 'telegram']);
+    });
+
+    it('CircuitBreaker 상태 맵 반영', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'telegram', success: true, responseTimeMs: 100 });
+
+      const cbStates = new Map<string, CircuitState>([
+        ['slack', CircuitState.CLOSED],
+        ['telegram', CircuitState.OPEN],
+      ]);
+
+      const all = stats.getAllStats(cbStates);
+      const slack = all.find(s => s.platform === 'slack');
+      const telegram = all.find(s => s.platform === 'telegram');
+      expect(slack!.circuitBreakerState).toBe(CircuitState.CLOSED);
+      expect(telegram!.circuitBreakerState).toBe(CircuitState.OPEN);
+    });
+
+    it('빈 상태에서 빈 배열 반환', () => {
+      expect(stats.getAllStats()).toEqual([]);
+    });
+  });
+
+  describe('리셋', () => {
+    it('특정 플랫폼 리셋', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'telegram', success: true, responseTimeMs: 100 });
+
+      expect(stats.resetPlatform('slack')).toBe(true);
+      expect(stats.getStats('slack')).toBeUndefined();
+      expect(stats.getStats('telegram')).toBeDefined();
+    });
+
+    it('존재하지 않는 플랫폼 리셋 시 false', () => {
+      expect(stats.resetPlatform('nonexistent')).toBe(false);
+    });
+
+    it('전체 리셋', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'telegram', success: true, responseTimeMs: 100 });
+
+      stats.resetAll();
+      expect(stats.getAllStats()).toEqual([]);
+    });
+  });
+
+  describe('스냅샷 불변성', () => {
+    it('반환된 통계 객체 수정이 원본에 영향을 주지 않음', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+
+      const snapshot1 = stats.getStats('slack')!;
+      snapshot1.totalSent = 999;
+
+      const snapshot2 = stats.getStats('slack')!;
+      expect(snapshot2.totalSent).toBe(1);
+    });
+
+    it('반환된 lastSuccessAt 수정이 내부 상태에 영향을 주지 않음', () => {
+      const ts = new Date('2026-01-15T10:00:00Z');
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: ts });
+
+      const snapshot1 = stats.getStats('slack')!;
+      snapshot1.lastSuccessAt!.setFullYear(2000);
+
+      const snapshot2 = stats.getStats('slack')!;
+      expect(snapshot2.lastSuccessAt!.getFullYear()).toBe(2026);
+    });
+
+    it('반환된 lastFailureAt 수정이 내부 상태에 영향을 주지 않음', () => {
+      const ts = new Date('2026-01-15T10:00:00Z');
+      stats.recordResult({ platform: 'slack', success: false, responseTimeMs: 100, timestamp: ts });
+
+      const snapshot1 = stats.getStats('slack')!;
+      snapshot1.lastFailureAt!.setFullYear(2000);
+
+      const snapshot2 = stats.getStats('slack')!;
+      expect(snapshot2.lastFailureAt!.getFullYear()).toBe(2026);
+    });
+  });
+
+  describe('입력 검증', () => {
+    it('빈 플랫폼명은 무시', () => {
+      stats.recordResult({ platform: '', success: true, responseTimeMs: 100 });
+      expect(stats.getAllStats()).toEqual([]);
+    });
+
+    it('공백만 있는 플랫폼명은 무시', () => {
+      stats.recordResult({ platform: '  ', success: true, responseTimeMs: 100 });
+      expect(stats.getAllStats()).toEqual([]);
+    });
+
+    it('음수 응답시간은 0으로 정규화', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: -100 });
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(0);
+    });
+
+    it('NaN 응답시간은 0으로 정규화', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: NaN });
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(0);
+    });
+
+    it('Infinity 응답시간은 0으로 정규화', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: Infinity });
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(0);
+    });
+  });
+
+  describe('getAllStats 정렬', () => {
+    it('플랫폼명 기준 알파벳순 정렬', () => {
+      stats.recordResult({ platform: 'telegram', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'discord', success: true, responseTimeMs: 100 });
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+
+      const all = stats.getAllStats();
+      expect(all.map(s => s.platform)).toEqual(['discord', 'slack', 'telegram']);
+    });
+  });
+});

--- a/src/__tests__/services/notifications/NotificationStats.test.ts
+++ b/src/__tests__/services/notifications/NotificationStats.test.ts
@@ -284,6 +284,28 @@ describe('NotificationStats', () => {
       stats.recordResult({ platform: 'slack', success: true, responseTimeMs: Infinity });
       expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(0);
     });
+
+    it('플랫폼명 앞뒤 공백은 trim 처리', () => {
+      stats.recordResult({ platform: '  slack  ', success: true, responseTimeMs: 100 });
+      expect(stats.getStats('slack')).toBeDefined();
+      expect(stats.getStats('slack')!.totalSent).toBe(1);
+      expect(stats.getStats('  slack  ')).toBeUndefined();
+    });
+
+    it('Invalid Date 타임스탬프는 현재 시각으로 대체', () => {
+      const invalidDate = new Date('invalid');
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100, timestamp: invalidDate });
+
+      const result = stats.getStats('slack')!;
+      expect(result.totalSent).toBe(1);
+      expect(result.lastSuccessAt).toBeInstanceOf(Date);
+      expect(Number.isFinite(result.lastSuccessAt!.getTime())).toBe(true);
+    });
+
+    it('-Infinity 응답시간은 0으로 정규화', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: -Infinity });
+      expect(stats.getStats('slack')!.averageResponseTimeMs).toBe(0);
+    });
   });
 
   describe('getAllStats 정렬', () => {

--- a/src/__tests__/services/notifications/NotificationStats.test.ts
+++ b/src/__tests__/services/notifications/NotificationStats.test.ts
@@ -289,7 +289,20 @@ describe('NotificationStats', () => {
       stats.recordResult({ platform: '  slack  ', success: true, responseTimeMs: 100 });
       expect(stats.getStats('slack')).toBeDefined();
       expect(stats.getStats('slack')!.totalSent).toBe(1);
-      expect(stats.getStats('  slack  ')).toBeUndefined();
+      // getStats도 trim 정규화 적용
+      expect(stats.getStats('  slack  ')).toBeDefined();
+      expect(stats.getStats('  slack  ')!.totalSent).toBe(1);
+    });
+
+    it('resetPlatform도 trim 정규화 적용', () => {
+      stats.recordResult({ platform: 'slack', success: true, responseTimeMs: 100 });
+      expect(stats.resetPlatform('  slack  ')).toBe(true);
+      expect(stats.getStats('slack')).toBeUndefined();
+    });
+
+    it('빈 플랫폼명으로 resetPlatform 시 false', () => {
+      expect(stats.resetPlatform('')).toBe(false);
+      expect(stats.resetPlatform('  ')).toBe(false);
     });
 
     it('Invalid Date 타임스탬프는 현재 시각으로 대체', () => {

--- a/src/services/notifications/MultiplatformNotificationService.ts
+++ b/src/services/notifications/MultiplatformNotificationService.ts
@@ -5,6 +5,7 @@ import { SubscriptionManager, UserSubscription, SubscriptionNotificationResult }
 import { HybridSubscriptionManager } from '../subscriptions/HybridSubscriptionManager';
 import { SubscriptionCommand } from '../subscriptions/interfaces';
 import { CircuitBreaker, CircuitBreakerOpenError, CircuitState } from './CircuitBreaker';
+import { NotificationStats, PlatformStats } from './NotificationStats';
 
 export interface RetryOptions {
   readonly maxRetries: number;
@@ -26,6 +27,7 @@ export class MultiplatformNotificationService {
   private subscriptionManager: SubscriptionManager;
   private hybridManager?: HybridSubscriptionManager;
   private readonly circuitBreakers: Map<string, CircuitBreaker> = new Map();
+  private readonly notificationStats: NotificationStats = new NotificationStats();
 
   constructor(services: NotificationService[] = [], subscriptionManager?: SubscriptionManager) {
     this.services = [...services];
@@ -272,7 +274,7 @@ export class MultiplatformNotificationService {
   }
 
   /**
-   * 플랫폼별 전송 성공률 통계 (CircuitBreaker 기반)
+   * 플랫폼별 전송 성공률 통계 (간략)
    */
   getStatistics(): { [platform: string]: { total: number; success: number; successRate: number } } {
     const stats: { [platform: string]: { total: number; success: number; successRate: number } } = {};
@@ -287,6 +289,38 @@ export class MultiplatformNotificationService {
     }
 
     return stats;
+  }
+
+  /**
+   * 플랫폼별 상세 통계 (응답시간, 시간대별 분포, CircuitBreaker 상태 포함)
+   */
+  getDetailedStatistics(): PlatformStats[] {
+    const cbStates = new Map<string, CircuitState>();
+    for (const [platform, cb] of this.circuitBreakers) {
+      cbStates.set(platform, cb.getState());
+    }
+    return this.notificationStats.getAllStats(cbStates);
+  }
+
+  /**
+   * 특정 플랫폼의 상세 통계
+   */
+  getDetailedPlatformStats(platformName: string): PlatformStats | undefined {
+    const cbState = this.circuitBreakers.get(platformName)?.getState();
+    return this.notificationStats.getStats(platformName, cbState);
+  }
+
+  /**
+   * 통계 초기화
+   */
+  resetStatistics(platformName?: string): void {
+    if (platformName) {
+      this.notificationStats.resetPlatform(platformName);
+      logger.info(`${platformName} 통계 초기화`);
+    } else {
+      this.notificationStats.resetAll();
+      logger.info('전체 플랫폼 통계 초기화');
+    }
   }
 
   /**
@@ -316,23 +350,43 @@ export class MultiplatformNotificationService {
     const results = await Promise.allSettled(
       services.map(async service => {
         const cb = this.circuitBreakers.get(service.platformName);
-        if (!cb) {
-          return service.sendAlert(alert);
-        }
+        const startTime = Date.now();
 
         try {
-          return await cb.execute(() => service.sendAlert(alert));
+          const result = cb
+            ? await cb.execute(() => service.sendAlert(alert))
+            : await service.sendAlert(alert);
+
+          const responseTime = Date.now() - startTime;
+          const resultWithTime = { ...result, responseTime };
+
+          this.notificationStats.recordResult({
+            platform: service.platformName,
+            success: resultWithTime.success,
+            responseTimeMs: responseTime,
+          });
+
+          return resultWithTime;
         } catch (error) {
+          const responseTime = Date.now() - startTime;
+
           if (error instanceof CircuitBreakerOpenError || (error as Error)?.name === 'CircuitBreakerOpenError') {
             logger.warn(`${service.platformName} Circuit breaker OPEN - 전송 건너뜀`);
           } else {
             logger.error(`${service.platformName} 특보 알림 전송 실패:`, error);
           }
+
+          this.notificationStats.recordResult({
+            platform: service.platformName,
+            success: false,
+            responseTimeMs: responseTime,
+          });
+
           return {
             platform: service.platformName,
             success: false,
             error: error instanceof Error ? error.message : String(error),
-            responseTime: 0,
+            responseTime,
           } as NotificationResult;
         }
       })

--- a/src/services/notifications/NotificationStats.ts
+++ b/src/services/notifications/NotificationStats.ts
@@ -30,14 +30,18 @@ export class NotificationStats {
   private readonly platforms: Map<string, PlatformStatsAccumulator> = new Map();
 
   recordResult(entry: RecordEntry): void {
-    if (!entry.platform || entry.platform.trim().length === 0) return;
+    const platform = entry.platform?.trim();
+    if (!platform || platform.length === 0) return;
 
     const responseTimeMs = Number.isFinite(entry.responseTimeMs) && entry.responseTimeMs >= 0
       ? entry.responseTimeMs
       : 0;
 
-    const acc = this.ensurePlatform(entry.platform);
-    const ts = entry.timestamp ?? new Date();
+    const ts = entry.timestamp instanceof Date && Number.isFinite(entry.timestamp.getTime())
+      ? entry.timestamp
+      : new Date();
+
+    const acc = this.ensurePlatform(platform);
 
     acc.totalSent++;
     acc.totalResponseTimeMs += responseTimeMs;

--- a/src/services/notifications/NotificationStats.ts
+++ b/src/services/notifications/NotificationStats.ts
@@ -1,0 +1,135 @@
+import { CircuitState } from './CircuitBreaker';
+
+export interface HourlyBucket {
+  readonly hour: number;
+  sent: number;
+  success: number;
+}
+
+export interface PlatformStats {
+  readonly platform: string;
+  totalSent: number;
+  successCount: number;
+  failureCount: number;
+  successRate: number;
+  averageResponseTimeMs: number;
+  lastSuccessAt: Date | null;
+  lastFailureAt: Date | null;
+  circuitBreakerState: CircuitState;
+  hourlyStats: HourlyBucket[];
+}
+
+export interface RecordEntry {
+  readonly platform: string;
+  readonly success: boolean;
+  readonly responseTimeMs: number;
+  readonly timestamp?: Date;
+}
+
+export class NotificationStats {
+  private readonly platforms: Map<string, PlatformStatsAccumulator> = new Map();
+
+  recordResult(entry: RecordEntry): void {
+    if (!entry.platform || entry.platform.trim().length === 0) return;
+
+    const responseTimeMs = Number.isFinite(entry.responseTimeMs) && entry.responseTimeMs >= 0
+      ? entry.responseTimeMs
+      : 0;
+
+    const acc = this.ensurePlatform(entry.platform);
+    const ts = entry.timestamp ?? new Date();
+
+    acc.totalSent++;
+    acc.totalResponseTimeMs += responseTimeMs;
+
+    const hour = ts.getUTCHours();
+    const bucket = acc.hourlyBuckets.get(hour) ?? { hour, sent: 0, success: 0 };
+    bucket.sent++;
+
+    if (entry.success) {
+      acc.successCount++;
+      acc.lastSuccessAt = ts;
+      bucket.success++;
+    } else {
+      acc.failureCount++;
+      acc.lastFailureAt = ts;
+    }
+
+    acc.hourlyBuckets.set(hour, bucket);
+  }
+
+  getStats(platform: string, circuitBreakerState?: CircuitState): PlatformStats | undefined {
+    const acc = this.platforms.get(platform);
+    if (!acc) return undefined;
+    return this.toSnapshot(platform, acc, circuitBreakerState ?? CircuitState.CLOSED);
+  }
+
+  getAllStats(circuitBreakerStates?: Map<string, CircuitState>): PlatformStats[] {
+    const results: PlatformStats[] = [];
+    for (const [platform, acc] of this.platforms) {
+      const cbState = circuitBreakerStates?.get(platform) ?? CircuitState.CLOSED;
+      results.push(this.toSnapshot(platform, acc, cbState));
+    }
+    return results.sort((a, b) => a.platform.localeCompare(b.platform));
+  }
+
+  resetPlatform(platform: string): boolean {
+    return this.platforms.delete(platform);
+  }
+
+  resetAll(): void {
+    this.platforms.clear();
+  }
+
+  private ensurePlatform(platform: string): PlatformStatsAccumulator {
+    let acc = this.platforms.get(platform);
+    if (!acc) {
+      acc = {
+        totalSent: 0,
+        successCount: 0,
+        failureCount: 0,
+        totalResponseTimeMs: 0,
+        lastSuccessAt: null,
+        lastFailureAt: null,
+        hourlyBuckets: new Map(),
+      };
+      this.platforms.set(platform, acc);
+    }
+    return acc;
+  }
+
+  private toSnapshot(
+    platform: string,
+    acc: PlatformStatsAccumulator,
+    circuitBreakerState: CircuitState
+  ): PlatformStats {
+    const hourlyStats: HourlyBucket[] = [];
+    for (let h = 0; h < 24; h++) {
+      const bucket = acc.hourlyBuckets.get(h);
+      hourlyStats.push(bucket ? { ...bucket } : { hour: h, sent: 0, success: 0 });
+    }
+
+    return {
+      platform,
+      totalSent: acc.totalSent,
+      successCount: acc.successCount,
+      failureCount: acc.failureCount,
+      successRate: acc.totalSent > 0 ? acc.successCount / acc.totalSent : 0,
+      averageResponseTimeMs: acc.totalSent > 0 ? acc.totalResponseTimeMs / acc.totalSent : 0,
+      lastSuccessAt: acc.lastSuccessAt ? new Date(acc.lastSuccessAt.getTime()) : null,
+      lastFailureAt: acc.lastFailureAt ? new Date(acc.lastFailureAt.getTime()) : null,
+      circuitBreakerState,
+      hourlyStats,
+    };
+  }
+}
+
+interface PlatformStatsAccumulator {
+  totalSent: number;
+  successCount: number;
+  failureCount: number;
+  totalResponseTimeMs: number;
+  lastSuccessAt: Date | null;
+  lastFailureAt: Date | null;
+  hourlyBuckets: Map<number, HourlyBucket>;
+}

--- a/src/services/notifications/NotificationStats.ts
+++ b/src/services/notifications/NotificationStats.ts
@@ -63,9 +63,11 @@ export class NotificationStats {
   }
 
   getStats(platform: string, circuitBreakerState?: CircuitState): PlatformStats | undefined {
-    const acc = this.platforms.get(platform);
+    const normalized = platform?.trim();
+    if (!normalized) return undefined;
+    const acc = this.platforms.get(normalized);
     if (!acc) return undefined;
-    return this.toSnapshot(platform, acc, circuitBreakerState ?? CircuitState.CLOSED);
+    return this.toSnapshot(normalized, acc, circuitBreakerState ?? CircuitState.CLOSED);
   }
 
   getAllStats(circuitBreakerStates?: Map<string, CircuitState>): PlatformStats[] {
@@ -78,7 +80,9 @@ export class NotificationStats {
   }
 
   resetPlatform(platform: string): boolean {
-    return this.platforms.delete(platform);
+    const normalized = platform?.trim();
+    if (!normalized) return false;
+    return this.platforms.delete(normalized);
   }
 
   resetAll(): void {

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -20,6 +20,10 @@ export { MultiplatformNotificationService } from './MultiplatformNotificationSer
 export { CircuitBreaker, CircuitBreakerOpenError, CircuitState } from './CircuitBreaker';
 export type { CircuitBreakerOptions } from './CircuitBreaker';
 
+// 알림 통계
+export { NotificationStats } from './NotificationStats';
+export type { PlatformStats, HourlyBucket, RecordEntry } from './NotificationStats';
+
 // 팩토리 클래스
 export { NotificationFactory } from './NotificationFactory';
 


### PR DESCRIPTION
## Summary
- **NotificationStats 클래스 신규 구현**: 플랫폼별 성공률, 평균 응답시간, 시간대별(UTC) 분포, 마지막 성공/실패 시각 추적
- **MultiplatformNotificationService 통합**: 모든 알림 전송 시 실제 응답시간 측정 및 자동 기록
- **Codex P1/P2 피드백 선반영**: Date 방어적 복사, 입력 검증, 정렬 보장

## Changes

### 새 파일
- `src/services/notifications/NotificationStats.ts` - 알림 통계 수집/조회 클래스
- `src/__tests__/services/notifications/NotificationStats.test.ts` - 33개 단위 테스트

### 변경 파일
- `src/services/notifications/MultiplatformNotificationService.ts` - 통계 기록 통합, 상세 통계 API 3개 추가
- `src/services/notifications/index.ts` - NotificationStats export 추가
- `src/__tests__/services/notifications/MultiplatformNotificationService.test.ts` - 통합 테스트 8개 추가

## Test plan
- [x] 성공률 계산 정확성 테스트 (100%, 0%, 혼합)
- [x] 평균 응답시간 계산 테스트
- [x] 시간대별(UTC) 통계 분포 테스트
- [x] Date 스냅샷 불변성 테스트 (P1 반영)
- [x] 입력 검증 테스트 (빈 플랫폼명, NaN/음수/Infinity 응답시간)
- [x] getAllStats 정렬 보장 테스트
- [x] MultiplatformNotificationService 통합 테스트
- [x] `npm run build` + `npm test` 834개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)