### PR TITLE
feat: 네비게이션 헤더 + 레이아웃 (#125)

### DIFF
--- a/web/app/dashboard/DashboardContent.tsx
+++ b/web/app/dashboard/DashboardContent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback } from 'react';
-import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useDashboardAlerts } from '@/hooks/useDashboardAlerts';
@@ -156,10 +155,6 @@ export default function DashboardContent() {
           heatmapPeriod={settings.heatmapPeriod}
           onHeatmapPeriodChange={settings.setHeatmapPeriod}
         />
-
-        <div className="text-center">
-          <Link href="/" className="text-blue-600 hover:underline">홈으로</Link>
-        </div>
       </div>
 
       <NotificationManager

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import "leaflet/dist/leaflet.css";
+import Header from "@/components/layout/Header";
+import Footer from "@/components/layout/Footer";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -17,7 +19,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} flex flex-col min-h-screen`}>
+        <Header />
+        <div className="flex-1">{children}</div>
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/web/app/monitoring/MonitoringContent.tsx
+++ b/web/app/monitoring/MonitoringContent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import Link from 'next/link';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -145,14 +144,9 @@ export default function MonitoringContent() {
       {/* 헤더 */}
       <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-6">
-          <div>
-            <Link href="/" className="text-sm text-blue-600 hover:underline mb-1 block">
-              &larr; 홈으로
-            </Link>
-            <h1 className="text-2xl font-bold text-gray-900">
-              알림 모니터링
-            </h1>
-          </div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            알림 모니터링
+          </h1>
           <div className="flex items-center gap-4">
             <label className="flex items-center gap-2 text-sm text-gray-600">
               <input

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -57,7 +57,7 @@ export default function Home() {
         </div>
 
         <div className="mt-12 text-center text-sm text-gray-500">
-          <p>Phase 1 MVP 개발 중...</p>
+          <p>v2.0.0-rc</p>
         </div>
       </div>
     </main>

--- a/web/app/settings/SettingsContent.tsx
+++ b/web/app/settings/SettingsContent.tsx
@@ -416,22 +416,6 @@ export default function SettingsContent() {
           </div>
         </div>
 
-        {/* 하단 링크 */}
-        <div className="text-center">
-          <Link
-            href="/dashboard"
-            className="text-blue-600 hover:underline"
-          >
-            📊 특보 현황 보기
-          </Link>
-          <span className="mx-3 text-gray-400">|</span>
-          <Link
-            href="/"
-            className="text-blue-600 hover:underline"
-          >
-            홈으로
-          </Link>
-        </div>
       </div>
     </main>
   );

--- a/web/components/layout/Footer.tsx
+++ b/web/components/layout/Footer.tsx
@@ -1,0 +1,11 @@
+export default function Footer() {
+  return (
+    <footer className="bg-white border-t border-gray-200 py-4">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <p className="text-center text-sm text-gray-400">
+          기상특보 현황 대시보드 &copy; {new Date().getFullYear()}
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/web/components/layout/Header.tsx
+++ b/web/components/layout/Header.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_ITEMS = [
+  { href: '/dashboard', label: '특보 현황' },
+  { href: '/settings', label: '구독 설정' },
+  { href: '/monitoring', label: '알림 모니터링' },
+] as const;
+
+export default function Header() {
+  const pathname = usePathname();
+
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-14">
+          <Link href="/" className="text-lg font-bold text-slate-800 hover:text-blue-600 transition-colors">
+            🌦️ 기상특보
+          </Link>
+
+          <nav className="flex items-center gap-1">
+            {NAV_ITEMS.map(({ href, label }) => {
+              const isActive = pathname === href || pathname?.startsWith(href + '/');
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    isActive
+                      ? 'bg-blue-50 text-blue-700'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+                  }`}
+                >
+                  {label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- 공통 Header 컴포넌트 신규 생성 (sticky, `usePathname` 기반 active page highlighting)
- Footer 컴포넌트 신규 생성
- `layout.tsx`에 Header/Footer 통합하여 모든 페이지에 일관된 네비게이션 제공
- DashboardContent, MonitoringContent, SettingsContent에서 중복 네비게이션 링크 제거
- 홈 페이지 버전 텍스트 `v2.0.0-rc`로 업데이트

## 변경 파일
| 파일 | 작업 |
|------|------|
| `web/components/layout/Header.tsx` | 신규 — sticky 헤더 + 네비게이션 |
| `web/components/layout/Footer.tsx` | 신규 — 푸터 |
| `web/app/layout.tsx` | 수정 — Header/Footer 통합 |
| `web/app/dashboard/DashboardContent.tsx` | 수정 — 홈 링크 제거 |
| `web/app/monitoring/MonitoringContent.tsx` | 수정 — 홈 링크 제거 |
| `web/app/settings/SettingsContent.tsx` | 수정 — 하단 네비게이션 제거 |
| `web/app/page.tsx` | 수정 — 버전 텍스트 업데이트 |

## Test plan
- [x] `npm run build` 통과
- [x] Codex CLI 리뷰 통과 (0 이슈)
- [ ] 모든 페이지에서 헤더 네비게이션 정상 동작 확인
- [ ] 현재 페이지 active 스타일 하이라이팅 확인
- [ ] 모바일 반응형 레이아웃 확인