### PR TITLE
feat(shared): @ku-weather/shared 패키지 — 공유 타입, 상수, 에러 클래스 (#142)

### DIFF
--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,0 +1,19 @@
+export {
+  WARNING_TYPE_NAMES,
+  WARNING_TYPE_EMOJI,
+  getWarningTypeName,
+  getWarningTypeEmoji,
+} from './warning-types';
+
+export {
+  WARNING_LEVEL_NAMES,
+  WARNING_LEVEL_EMOJI,
+  WARNING_LEVEL_COLORS,
+  getWarningLevelName,
+  getWarningLevelEmoji,
+} from './warning-levels';
+
+export {
+  WARNING_COMMAND_NAMES,
+  getWarningCommandName,
+} from './warning-commands';

--- a/packages/shared/src/constants/warning-commands.ts
+++ b/packages/shared/src/constants/warning-commands.ts
@@ -16,6 +16,7 @@ export const WARNING_COMMAND_NAMES: Readonly<Record<WeatherCommandCode, string>>
 };
 
 /** 특보 명령 코드를 한글 이름으로 변환 */
-export function getWarningCommandName(code: string): string {
-  return WARNING_COMMAND_NAMES[code.trim() as WeatherCommandCode] ?? code;
+export function getWarningCommandName(code: string | null | undefined): string {
+  const normalized = typeof code === 'string' ? code.trim() : '';
+  return WARNING_COMMAND_NAMES[normalized as WeatherCommandCode] ?? normalized;
 }

--- a/packages/shared/src/constants/warning-commands.ts
+++ b/packages/shared/src/constants/warning-commands.ts
@@ -1,0 +1,21 @@
+/**
+ * 특보 명령 관련 상수
+ */
+
+import type { WeatherCommandCode } from '../types/weather';
+
+/** 특보 명령별 한글 이름 */
+export const WARNING_COMMAND_NAMES: Readonly<Record<WeatherCommandCode, string>> = {
+  '1': '발표',
+  '2': '대치',
+  '3': '해제',
+  '4': '대치해제(자동)',
+  '5': '연장',
+  '6': '변경',
+  '7': '변경해제',
+};
+
+/** 특보 명령 코드를 한글 이름으로 변환 */
+export function getWarningCommandName(code: string): string {
+  return WARNING_COMMAND_NAMES[code.trim() as WeatherCommandCode] ?? code;
+}

--- a/packages/shared/src/constants/warning-levels.ts
+++ b/packages/shared/src/constants/warning-levels.ts
@@ -1,0 +1,36 @@
+/**
+ * 특보 수준 관련 상수
+ */
+
+import type { WeatherWarningLevel } from '../types/weather';
+
+/** 특보 수준별 한글 이름 */
+export const WARNING_LEVEL_NAMES: Readonly<Record<WeatherWarningLevel, string>> = {
+  '1': '예비특보',
+  '2': '주의보',
+  '3': '경보',
+};
+
+/** 특보 수준별 이모지 */
+export const WARNING_LEVEL_EMOJI: Readonly<Record<WeatherWarningLevel, string>> = {
+  '1': '🟡',
+  '2': '🟠',
+  '3': '🔴',
+};
+
+/** 특보 수준별 Tailwind CSS 색상 클래스 */
+export const WARNING_LEVEL_COLORS: Readonly<Record<WeatherWarningLevel, string>> = {
+  '1': 'bg-[#bfdbfe] border-blue-500 text-blue-900',
+  '2': 'bg-[#fde047] border-yellow-600 text-yellow-900',
+  '3': 'bg-[#dc2626] border-red-700 text-white',
+};
+
+/** 특보 수준 코드를 한글 이름으로 변환 */
+export function getWarningLevelName(code: string): string {
+  return WARNING_LEVEL_NAMES[code.trim() as WeatherWarningLevel] ?? code;
+}
+
+/** 특보 수준 코드를 이모지로 변환 */
+export function getWarningLevelEmoji(code: string): string {
+  return WARNING_LEVEL_EMOJI[code.trim() as WeatherWarningLevel] ?? '⚠️';
+}

--- a/packages/shared/src/constants/warning-levels.ts
+++ b/packages/shared/src/constants/warning-levels.ts
@@ -26,11 +26,13 @@ export const WARNING_LEVEL_COLORS: Readonly<Record<WeatherWarningLevel, string>>
 };
 
 /** 특보 수준 코드를 한글 이름으로 변환 */
-export function getWarningLevelName(code: string): string {
-  return WARNING_LEVEL_NAMES[code.trim() as WeatherWarningLevel] ?? code;
+export function getWarningLevelName(code: string | null | undefined): string {
+  const normalized = typeof code === 'string' ? code.trim() : '';
+  return WARNING_LEVEL_NAMES[normalized as WeatherWarningLevel] ?? normalized;
 }
 
 /** 특보 수준 코드를 이모지로 변환 */
-export function getWarningLevelEmoji(code: string): string {
-  return WARNING_LEVEL_EMOJI[code.trim() as WeatherWarningLevel] ?? '⚠️';
+export function getWarningLevelEmoji(code: string | null | undefined): string {
+  const normalized = typeof code === 'string' ? code.trim() : '';
+  return WARNING_LEVEL_EMOJI[normalized as WeatherWarningLevel] ?? '⚠️';
 }

--- a/packages/shared/src/constants/warning-types.ts
+++ b/packages/shared/src/constants/warning-types.ts
@@ -1,0 +1,47 @@
+/**
+ * 특보 종류 관련 상수
+ */
+
+import type { WeatherWarningType } from '../types/weather';
+
+/** 특보 종류별 한글 이름 */
+export const WARNING_TYPE_NAMES: Readonly<Record<WeatherWarningType, string>> = {
+  W: '강풍',
+  R: '호우',
+  C: '한파',
+  D: '건조',
+  O: '해일',
+  N: '지진해일',
+  V: '풍랑',
+  T: '태풍',
+  S: '대설',
+  Y: '황사',
+  H: '폭염',
+  F: '안개',
+};
+
+/** 특보 종류별 이모지 */
+export const WARNING_TYPE_EMOJI: Readonly<Record<WeatherWarningType, string>> = {
+  W: '💨',
+  R: '🌧️',
+  C: '🥶',
+  D: '🔥',
+  O: '🌊',
+  N: '🌊',
+  V: '🌊',
+  T: '🌀',
+  S: '❄️',
+  Y: '🟡',
+  H: '☀️',
+  F: '🌫️',
+};
+
+/** 특보 종류 코드를 한글 이름으로 변환 */
+export function getWarningTypeName(code: string): string {
+  return WARNING_TYPE_NAMES[code.trim() as WeatherWarningType] ?? code;
+}
+
+/** 특보 종류 코드를 이모지로 변환 */
+export function getWarningTypeEmoji(code: string): string {
+  return WARNING_TYPE_EMOJI[code.trim() as WeatherWarningType] ?? '⚠️';
+}

--- a/packages/shared/src/constants/warning-types.ts
+++ b/packages/shared/src/constants/warning-types.ts
@@ -37,11 +37,13 @@ export const WARNING_TYPE_EMOJI: Readonly<Record<WeatherWarningType, string>> = 
 };
 
 /** 특보 종류 코드를 한글 이름으로 변환 */
-export function getWarningTypeName(code: string): string {
-  return WARNING_TYPE_NAMES[code.trim() as WeatherWarningType] ?? code;
+export function getWarningTypeName(code: string | null | undefined): string {
+  const normalized = typeof code === 'string' ? code.trim() : '';
+  return WARNING_TYPE_NAMES[normalized as WeatherWarningType] ?? normalized;
 }
 
 /** 특보 종류 코드를 이모지로 변환 */
-export function getWarningTypeEmoji(code: string): string {
-  return WARNING_TYPE_EMOJI[code.trim() as WeatherWarningType] ?? '⚠️';
+export function getWarningTypeEmoji(code: string | null | undefined): string {
+  const normalized = typeof code === 'string' ? code.trim() : '';
+  return WARNING_TYPE_EMOJI[normalized as WeatherWarningType] ?? '⚠️';
 }

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * 공유 에러 계층
+ */
+
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly statusCode: number = 500,
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(resource: string) {
+    super(`${resource} not found`, 'NOT_FOUND', 404);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(message, 'VALIDATION_ERROR', 400);
+    this.name = 'ValidationError';
+  }
+}
+
+export class ExternalServiceError extends AppError {
+  constructor(service: string, cause?: Error) {
+    super(`External service error: ${service}`, 'EXTERNAL_SERVICE_ERROR', 502);
+    this.name = 'ExternalServiceError';
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,59 @@
-// @ku-weather/shared
-// 공유 타입, 상수, 에러 클래스 (Phase 1에서 채움)
+// Types
+export type {
+  WeatherWarningType,
+  WeatherWarningLevel,
+  WeatherCommandCode,
+  AlertChangeType,
+  WeatherAlertDto,
+  CachedAlert,
+  AlertChange,
+  WeatherForecast,
+  ForecastResult,
+} from './types/weather';
 
-export {};
+export { SkyCondition, PrecipitationType } from './types/weather';
+
+export type {
+  ApiResponse,
+  PaginationMeta,
+  AlertFilters,
+  AlertHistoryFilters,
+  StatisticsParams,
+} from './types/api';
+
+export type {
+  NotificationPlatform,
+  NotificationResult,
+  PlatformStats,
+  CircuitBreakerState,
+} from './types/notification';
+
+export type {
+  UserSubscription,
+  SubscriptionPreferences,
+  Region,
+  WarningType,
+} from './types/subscription';
+
+// Constants
+export {
+  WARNING_TYPE_NAMES,
+  WARNING_TYPE_EMOJI,
+  getWarningTypeName,
+  getWarningTypeEmoji,
+  WARNING_LEVEL_NAMES,
+  WARNING_LEVEL_EMOJI,
+  WARNING_LEVEL_COLORS,
+  getWarningLevelName,
+  getWarningLevelEmoji,
+  WARNING_COMMAND_NAMES,
+  getWarningCommandName,
+} from './constants';
+
+// Errors
+export {
+  AppError,
+  NotFoundError,
+  ValidationError,
+  ExternalServiceError,
+} from './errors';

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -1,0 +1,42 @@
+/**
+ * API 응답 공유 타입
+ */
+
+/** 표준 API 응답 envelope */
+export interface ApiResponse<T = unknown> {
+  readonly success: boolean;
+  readonly data?: T;
+  readonly count?: number;
+  readonly message?: string;
+  readonly error?: string;
+  readonly meta?: PaginationMeta;
+}
+
+/** 페이지네이션 메타 */
+export interface PaginationMeta {
+  readonly total: number;
+  readonly page: number;
+  readonly limit: number;
+}
+
+/** 특보 필터 (쿼리 파라미터) */
+export interface AlertFilters {
+  readonly regionId?: string;
+  readonly warningType?: string;
+  readonly warningLevel?: string;
+  readonly upperRegion?: string;
+}
+
+/** 특보 이력 필터 */
+export interface AlertHistoryFilters extends AlertFilters {
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly changeType?: string;
+}
+
+/** 통계 파라미터 */
+export interface StatisticsParams {
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly groupBy: 'region' | 'warningType' | 'level';
+}

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -31,7 +31,7 @@ export interface AlertFilters {
 export interface AlertHistoryFilters extends AlertFilters {
   readonly startDate: string;
   readonly endDate: string;
-  readonly changeType?: string;
+  readonly changeType?: import('./weather').AlertChangeType;
 }
 
 /** 통계 파라미터 */

--- a/packages/shared/src/types/notification.ts
+++ b/packages/shared/src/types/notification.ts
@@ -1,0 +1,29 @@
+/**
+ * 알림 시스템 공유 타입
+ */
+
+/** 알림 플랫폼 */
+export type NotificationPlatform = 'slack' | 'telegram' | 'discord' | 'email';
+
+/** 알림 전송 결과 */
+export interface NotificationResult {
+  readonly platform: NotificationPlatform;
+  readonly success: boolean;
+  readonly error?: string;
+  readonly responseTimeMs?: number;
+}
+
+/** 플랫폼별 통계 */
+export interface PlatformStats {
+  readonly totalSent: number;
+  readonly successCount: number;
+  readonly failureCount: number;
+  readonly successRate: number;
+  readonly averageResponseTimeMs: number;
+  readonly lastSuccessAt: string | null;
+  readonly lastFailureAt: string | null;
+  readonly circuitBreakerState: 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+}
+
+/** Circuit Breaker 상태 */
+export type CircuitBreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';

--- a/packages/shared/src/types/subscription.ts
+++ b/packages/shared/src/types/subscription.ts
@@ -1,0 +1,45 @@
+/**
+ * 구독 관리 공유 타입
+ */
+
+import type { NotificationPlatform } from './notification';
+
+/** 사용자 구독 */
+export interface UserSubscription {
+  readonly platform: NotificationPlatform | string;
+  readonly userId: string;
+  readonly targetRegions: readonly string[];
+  readonly warningTypes: readonly string[];
+  readonly enabled: boolean;
+  readonly displayName: string;
+  readonly regionNames?: readonly string[];
+  readonly warningTypeNames?: readonly string[];
+  readonly platformDisplayName?: string;
+  readonly preferences?: SubscriptionPreferences;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+}
+
+/** 구독 설정 */
+export interface SubscriptionPreferences {
+  readonly minLevel?: string;
+  readonly quietHours?: {
+    readonly start: string;
+    readonly end: string;
+  } | null;
+  readonly batchMode?: boolean;
+}
+
+/** 지역 정보 */
+export interface Region {
+  readonly code: string;
+  readonly name: string;
+  readonly aliases: readonly string[];
+}
+
+/** 특보 종류 정보 */
+export interface WarningType {
+  readonly code: string;
+  readonly name: string;
+  readonly aliases: readonly string[];
+}

--- a/packages/shared/src/types/subscription.ts
+++ b/packages/shared/src/types/subscription.ts
@@ -6,7 +6,7 @@ import type { NotificationPlatform } from './notification';
 
 /** 사용자 구독 */
 export interface UserSubscription {
-  readonly platform: NotificationPlatform | string;
+  readonly platform: NotificationPlatform;
   readonly userId: string;
   readonly targetRegions: readonly string[];
   readonly warningTypes: readonly string[];

--- a/packages/shared/src/types/weather.ts
+++ b/packages/shared/src/types/weather.ts
@@ -77,8 +77,8 @@ export interface AlertChange {
 export interface WeatherForecast {
   readonly regionId: string;
   readonly regionName: string;
-  readonly baseTime: Date;
-  readonly forecastTime: Date;
+  readonly baseTime: string;
+  readonly forecastTime: string;
   readonly temperature?: number;
   readonly feelsLike?: number;
   readonly minTemperature?: number;

--- a/packages/shared/src/types/weather.ts
+++ b/packages/shared/src/types/weather.ts
@@ -1,0 +1,122 @@
+/**
+ * 기상특보 공유 타입 정의
+ * 백엔드 API 응답 / 프론트엔드 공통으로 사용하는 타입
+ */
+
+/** 특보 종류 코드 */
+export type WeatherWarningType = 'W' | 'R' | 'C' | 'D' | 'O' | 'N' | 'V' | 'T' | 'S' | 'Y' | 'H' | 'F';
+
+/** 특보 수준 코드 */
+export type WeatherWarningLevel = '1' | '2' | '3';
+
+/** 특보 명령 코드 */
+export type WeatherCommandCode = '1' | '2' | '3' | '4' | '5' | '6' | '7';
+
+/**
+ * 특보 변동 유형
+ */
+export type AlertChangeType =
+  | 'NEW'
+  | 'RESOLVED'
+  | 'LEVEL_UP'
+  | 'LEVEL_DOWN'
+  | 'TIME_EXTENDED'
+  | 'MODIFIED';
+
+/**
+ * 기상특보 DTO (DB/API 응답 형태)
+ * Prisma WeatherAlert 모델과 동일한 필드
+ */
+export interface WeatherAlertDto {
+  readonly id: string;
+  readonly regionId: string;
+  readonly regionName: string;
+  readonly upperRegion: string | null;
+  readonly warningType: string;
+  readonly warningLevel: string;
+  readonly command: string;
+  readonly announcedAt: string;
+  readonly effectiveAt: string;
+  readonly endTime: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+/**
+ * 캐시된 특보 데이터
+ * 변동 감지를 위해 간소화된 특보 정보
+ */
+export interface CachedAlert {
+  readonly key: string;
+  readonly regionId: string;
+  readonly regionName: string;
+  readonly upperRegion?: string;
+  readonly warningType: string;
+  readonly level: string;
+  readonly command: string;
+  readonly announcedAt: string;
+  readonly effectiveAt: string;
+  readonly lastUpdated: string;
+  readonly lastSeenAt?: string;
+  readonly endTime?: string;
+}
+
+/**
+ * 특보 변동 정보
+ */
+export interface AlertChange {
+  readonly type: AlertChangeType;
+  readonly current?: CachedAlert;
+  readonly previous?: CachedAlert;
+  readonly description: string;
+}
+
+/**
+ * 단기예보 데이터
+ */
+export interface WeatherForecast {
+  readonly regionId: string;
+  readonly regionName: string;
+  readonly baseTime: Date;
+  readonly forecastTime: Date;
+  readonly temperature?: number;
+  readonly feelsLike?: number;
+  readonly minTemperature?: number;
+  readonly maxTemperature?: number;
+  readonly precipitationProbability?: number;
+  readonly precipitation?: number;
+  readonly humidity?: number;
+  readonly skyCondition?: number;
+  readonly precipitationType?: number;
+  readonly windSpeed?: number;
+  readonly windDirection?: number;
+  readonly lightningProbability?: number;
+}
+
+/**
+ * 예보 조회 결과
+ */
+export interface ForecastResult {
+  readonly success: boolean;
+  readonly data: WeatherForecast | null;
+  readonly error?: string;
+  readonly source?: 'ultra-short' | 'village' | 'merged';
+}
+
+/** 하늘상태 코드 */
+export enum SkyCondition {
+  CLEAR = 1,
+  PARTLY_CLOUDY = 3,
+  CLOUDY = 4,
+}
+
+/** 강수형태 코드 */
+export enum PrecipitationType {
+  NONE = 0,
+  RAIN = 1,
+  RAIN_SNOW = 2,
+  SNOW = 3,
+  RAIN_DROP = 5,
+  RAIN_DROP_SNOW = 6,
+  SNOW_FLURRY = 7,
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "lib": ["ES2022"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

`@ku-weather/shared` 패키지에 백엔드/프론트엔드 간 공유 타입, 상수, 에러 클래스를 추가합니다.

- **공유 타입**: `WeatherAlertDto`, `CachedAlert`, `AlertChange`, `WeatherForecast`, `ApiResponse<T>`, `UserSubscription`, `PlatformStats` 등
- **공유 상수**: `WARNING_TYPE_NAMES`, `WARNING_LEVEL_NAMES`, `WARNING_TYPE_EMOJI`, `WARNING_LEVEL_COLORS`, `WARNING_COMMAND_NAMES` + 헬퍼 함수
- **에러 계층**: `AppError` → `NotFoundError`, `ValidationError`, `ExternalServiceError`

> 기존 코드의 import 변경은 Phase 2 이후 모듈 이동 시 진행합니다.

Closes #142

## 변경 파일

| 파일 | 설명 |
|------|------|
| `packages/shared/src/types/weather.ts` | WeatherAlertDto, CachedAlert, AlertChange, WeatherForecast 등 |
| `packages/shared/src/types/api.ts` | ApiResponse<T>, AlertFilters, AlertHistoryFilters |
| `packages/shared/src/types/notification.ts` | NotificationPlatform, PlatformStats |
| `packages/shared/src/types/subscription.ts` | UserSubscription, Region, WarningType |
| `packages/shared/src/constants/` | 특보 타입/수준/명령 상수 + null-safe 헬퍼 |
| `packages/shared/src/errors.ts` | 에러 계층 |
| `packages/shared/src/index.ts` | Barrel export |
| `packages/shared/tsconfig.json` | lib ES2022 (Error.cause 지원) |

## 검증

- [x] `pnpm --filter @ku-weather/shared build` 통과
- [x] `npm run build` (tsc) 통과
- [x] `npm test` 851개 테스트 통과
- [x] Codex 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과

- 리뷰 2회 (1차: P2 1건 + P1 3건 → 수정 → 2차: P0/P1/P2 모두 0건)