### PR TITLE
feat(infra): 백엔드 인프라 레이어 분리 + Zod 환경변수 검증 (#143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "express": "^5.1.0",
     "iconv-lite": "^0.6.3",
     "node-telegram-bot-api": "^0.66.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "zod": "^4.3.6"
   },
   "overrides": {
     "body-parser": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/cors':
         specifier: ^2.8.19
@@ -2553,6 +2556,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -5582,3 +5588,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.3.6: {}

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod/v4';
+
+/** boolean 환경변수 헬퍼: 문자열 'true'/'false' → boolean */
+const booleanEnv = (defaultValue: string = 'false') =>
+  z.string().default(defaultValue).transform(v => v === 'true');
+
+/** comma-separated 환경변수 헬퍼: "a,b,c" → ["a","b","c"] */
+const csvEnv = () =>
+  z.string().default('').transform(s => s.split(',').filter(Boolean));
+
+/**
+ * 환경변수 검증 스키마 (Zod v4)
+ * 앱 시작 시 환경변수의 타입 안전성을 보장
+ */
+export const envSchema = z.object({
+  // 기상청 API
+  WEATHER_API_KEY: z.string().min(1, 'WEATHER_API_KEY 환경변수가 설정되지 않았습니다'),
+
+  // Slack
+  SLACK_WEBHOOK_URL: z.url('SLACK_WEBHOOK_URL은 유효한 URL이어야 합니다'),
+  SLACK_BATCH_MODE: booleanEnv('true'),
+
+  // 모니터링 설정
+  TARGET_REGION_IDS: csvEnv(),
+  WARNING_TYPES: csvEnv(),
+  SUBCD: z.string().optional(),
+  CHECK_INTERVAL_MINUTES: z.coerce.number().positive('CHECK_INTERVAL_MINUTES는 양수여야 합니다').default(30),
+
+  // 환경
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  ENVIRONMENT: z.string().default('development'),
+  DEBUG: booleanEnv('false'),
+
+  // Telegram
+  TELEGRAM_BOT_TOKEN: z.string().default(''),
+  TELEGRAM_CHAT_ID: z.string().optional(),
+  TELEGRAM_ENABLED: booleanEnv('false'),
+  TELEGRAM_WEBHOOK_URL: z.string().optional(),
+  TELEGRAM_WEBHOOK_SECRET: z.string().optional(),
+
+  // HTTP 서버
+  PORT: z.coerce.number().default(3000),
+  SERVER_ENABLED: booleanEnv('true'),
+  CORS_ORIGIN: z.string().optional(),
+
+  // 웹 대시보드
+  WEB_DASHBOARD_URL: z.string().default('https://weather.starryjeju.net'),
+
+  // 데이터베이스
+  DATABASE_URL: z.string().optional(),
+});
+
+export type EnvConfig = z.infer<typeof envSchema>;
+
+/**
+ * 환경변수를 파싱하고 검증
+ * 실패 시 상세 에러 메시지와 함께 예외 발생
+ */
+export function parseEnv(env: Record<string, string | undefined> = process.env): EnvConfig {
+  const result = envSchema.safeParse(env);
+
+  if (!result.success) {
+    const errors = result.error.issues
+      .map(issue => `  - ${issue.path.join('.')}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`환경변수 검증 실패:\n${errors}`);
+  }
+
+  return result.data;
+}

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -1,12 +1,22 @@
 import { z } from 'zod/v4';
 
-/** boolean 환경변수 헬퍼: 문자열 'true'/'false' → boolean */
-const booleanEnv = (defaultValue: string = 'false') =>
+/**
+ * boolean 환경변수 헬퍼 (opt-in): 'true'만 true, 나머지는 false
+ * 기본값이 false인 플래그에 사용 (예: TELEGRAM_ENABLED, DEBUG)
+ */
+const booleanOptIn = (defaultValue: string = 'false') =>
   z.string().default(defaultValue).transform(v => v === 'true');
 
-/** comma-separated 환경변수 헬퍼: "a,b,c" → ["a","b","c"] */
+/**
+ * boolean 환경변수 헬퍼 (opt-out): 'false'만 false, 나머지는 true
+ * 기본값이 true인 플래그에 사용 (예: SLACK_BATCH_MODE, SERVER_ENABLED)
+ */
+const booleanOptOut = () =>
+  z.string().default('true').transform(v => v !== 'false');
+
+/** comma-separated 환경변수 헬퍼: "a, b, c" → ["a","b","c"] */
 const csvEnv = () =>
-  z.string().default('').transform(s => s.split(',').filter(Boolean));
+  z.string().default('').transform(s => s.split(',').map(v => v.trim()).filter(v => v.length > 0));
 
 /**
  * 환경변수 검증 스키마 (Zod v4)
@@ -18,7 +28,7 @@ export const envSchema = z.object({
 
   // Slack
   SLACK_WEBHOOK_URL: z.url('SLACK_WEBHOOK_URL은 유효한 URL이어야 합니다'),
-  SLACK_BATCH_MODE: booleanEnv('true'),
+  SLACK_BATCH_MODE: booleanOptOut(),
 
   // 모니터링 설정
   TARGET_REGION_IDS: csvEnv(),
@@ -29,18 +39,18 @@ export const envSchema = z.object({
   // 환경
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   ENVIRONMENT: z.string().default('development'),
-  DEBUG: booleanEnv('false'),
+  DEBUG: booleanOptIn('false'),
 
   // Telegram
   TELEGRAM_BOT_TOKEN: z.string().default(''),
   TELEGRAM_CHAT_ID: z.string().optional(),
-  TELEGRAM_ENABLED: booleanEnv('false'),
+  TELEGRAM_ENABLED: booleanOptIn('false'),
   TELEGRAM_WEBHOOK_URL: z.string().optional(),
   TELEGRAM_WEBHOOK_SECRET: z.string().optional(),
 
   // HTTP 서버
   PORT: z.coerce.number().default(3000),
-  SERVER_ENABLED: booleanEnv('true'),
+  SERVER_ENABLED: booleanOptOut(),
   CORS_ORIGIN: z.string().optional(),
 
   // 웹 대시보드
@@ -48,7 +58,41 @@ export const envSchema = z.object({
 
   // 데이터베이스
   DATABASE_URL: z.string().optional(),
-});
+}).check(
+  z.check<{
+    TELEGRAM_ENABLED: boolean;
+    TELEGRAM_BOT_TOKEN: string;
+    TELEGRAM_WEBHOOK_URL?: string;
+    TELEGRAM_WEBHOOK_SECRET?: string;
+  }>(ctx => {
+    if (!ctx.value.TELEGRAM_ENABLED) return;
+
+    if (!ctx.value.TELEGRAM_BOT_TOKEN) {
+      ctx.issues.push({
+        message: 'TELEGRAM_ENABLED=true일 때 TELEGRAM_BOT_TOKEN은 필수입니다',
+        path: ['TELEGRAM_BOT_TOKEN'],
+        input: ctx.value.TELEGRAM_BOT_TOKEN,
+        code: 'custom',
+      });
+    }
+    if (!ctx.value.TELEGRAM_WEBHOOK_URL) {
+      ctx.issues.push({
+        message: 'TELEGRAM_ENABLED=true일 때 TELEGRAM_WEBHOOK_URL은 필수입니다',
+        path: ['TELEGRAM_WEBHOOK_URL'],
+        input: ctx.value.TELEGRAM_WEBHOOK_URL,
+        code: 'custom',
+      });
+    }
+    if (!ctx.value.TELEGRAM_WEBHOOK_SECRET) {
+      ctx.issues.push({
+        message: 'TELEGRAM_ENABLED=true일 때 TELEGRAM_WEBHOOK_SECRET은 필수입니다',
+        path: ['TELEGRAM_WEBHOOK_SECRET'],
+        input: ctx.value.TELEGRAM_WEBHOOK_SECRET,
+        code: 'custom',
+      });
+    }
+  }),
+);
 
 export type EnvConfig = z.infer<typeof envSchema>;
 

--- a/src/infra/database/prisma-client.ts
+++ b/src/infra/database/prisma-client.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+import { logger } from '../../utils/logger';
+
+let prismaInstance: PrismaClient | null = null;
+
+/**
+ * Prisma 클라이언트 싱글턴
+ * 애플리케이션 전체에서 하나의 인스턴스만 사용
+ */
+export function getPrismaClient(): PrismaClient {
+  if (!prismaInstance) {
+    prismaInstance = new PrismaClient();
+    logger.info('Prisma client initialized');
+  }
+  return prismaInstance;
+}
+
+/**
+ * Prisma 연결 해제 (graceful shutdown 시 사용)
+ */
+export async function disconnectPrisma(): Promise<void> {
+  if (prismaInstance) {
+    await prismaInstance.$disconnect();
+    prismaInstance = null;
+    logger.info('Prisma client disconnected');
+  }
+}

--- a/src/infra/http/middleware/error-handler.ts
+++ b/src/infra/http/middleware/error-handler.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../../../utils/logger';
+
+export function errorHandler(environment: string) {
+  return (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+    logger.error('Unhandled error:', err);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: environment === 'development' ? err.message : undefined,
+    });
+  };
+}
+
+export function notFoundHandler(_req: Request, res: Response): void {
+  res.status(404).json({
+    error: 'Not Found',
+    path: _req.path,
+  });
+}

--- a/src/infra/http/middleware/index.ts
+++ b/src/infra/http/middleware/index.ts
@@ -1,0 +1,3 @@
+export { requestLogger } from './request-logger';
+export { errorHandler, notFoundHandler } from './error-handler';
+export { telegramWebhookAuth } from './telegram-auth';

--- a/src/infra/http/middleware/request-logger.ts
+++ b/src/infra/http/middleware/request-logger.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../../../utils/logger';
+
+export function requestLogger(req: Request, _res: Response, next: NextFunction): void {
+  logger.debug(`${req.method} ${req.path}`);
+  next();
+}

--- a/src/infra/http/middleware/telegram-auth.ts
+++ b/src/infra/http/middleware/telegram-auth.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import { timingSafeEqual } from 'crypto';
+import { logger } from '../../../utils/logger';
+
+/**
+ * Telegram Webhook 인증 미들웨어
+ * timing-safe comparison으로 secret 검증
+ */
+export function telegramWebhookAuth(configuredSecret: string | undefined) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!configuredSecret) {
+      logger.error('Telegram webhook secret is not configured. Rejecting request.');
+      res.status(500).json({ ok: false, error: 'Webhook not configured' });
+      return;
+    }
+
+    const providedSecret = req.get('x-telegram-bot-api-secret-token');
+    if (!providedSecret) {
+      logger.warn('Missing Telegram webhook secret token');
+      res.status(403).json({ ok: false, error: 'Invalid webhook token' });
+      return;
+    }
+
+    const providedSecretBuffer = Buffer.from(providedSecret, 'utf8');
+    const configuredSecretBuffer = Buffer.from(configuredSecret, 'utf8');
+
+    const secretsMatch =
+      providedSecretBuffer.length === configuredSecretBuffer.length &&
+      timingSafeEqual(providedSecretBuffer, configuredSecretBuffer);
+
+    if (!secretsMatch) {
+      logger.warn('Invalid Telegram webhook secret token received');
+      res.status(403).json({ ok: false, error: 'Invalid webhook token' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/infra/index.ts
+++ b/src/infra/index.ts
@@ -1,0 +1,4 @@
+export { requestLogger, errorHandler, notFoundHandler, telegramWebhookAuth } from './http/middleware';
+export { SocketServer } from './websocket/socket-server';
+export type { SocketServerConfig } from './websocket/socket-server';
+export { getPrismaClient, disconnectPrisma } from './database/prisma-client';

--- a/src/infra/websocket/socket-server.ts
+++ b/src/infra/websocket/socket-server.ts
@@ -1,0 +1,82 @@
+import { Server as HttpServerType } from 'http';
+import { Server as SocketIOServer } from 'socket.io';
+import { logger } from '../../utils/logger';
+import { AlertChange } from '../../types/weather';
+
+export interface SocketServerConfig {
+  readonly corsOrigin: string;
+}
+
+/**
+ * Socket.IO 서버
+ * 실시간 특보 변동 브로드캐스트 담당
+ */
+export class SocketServer {
+  private io: SocketIOServer;
+
+  constructor(httpServer: HttpServerType, config: SocketServerConfig) {
+    this.io = new SocketIOServer(httpServer, {
+      cors: {
+        origin: config.corsOrigin,
+        methods: ['GET', 'POST'],
+      },
+      transports: ['websocket', 'polling'],
+    });
+
+    this.setupConnectionHandlers();
+  }
+
+  private setupConnectionHandlers(): void {
+    this.io.on('connection', (socket) => {
+      logger.info(`[WebSocket] Client connected: ${socket.id}`);
+
+      socket.on('disconnect', (reason) => {
+        logger.info(`[WebSocket] Client disconnected: ${socket.id}, reason: ${reason}`);
+      });
+
+      socket.on('error', (error) => {
+        logger.error(`[WebSocket] Socket error: ${socket.id}`, error);
+      });
+    });
+  }
+
+  /**
+   * 특보 변동사항을 연결된 모든 클라이언트에 브로드캐스트
+   */
+  broadcastAlertChanges(changes: readonly AlertChange[]): void {
+    for (const change of changes) {
+      switch (change.type) {
+        case 'NEW':
+          if (change.current) {
+            this.io.emit('alert:new', change.current);
+            logger.debug(`[WebSocket] Broadcast alert:new - ${change.current.regionName} ${change.current.warningType}`);
+          }
+          break;
+
+        case 'RESOLVED':
+          if (change.previous) {
+            const alertId = `${change.previous.regionId}_${change.previous.warningType}`;
+            this.io.emit('alert:removed', alertId);
+            logger.debug(`[WebSocket] Broadcast alert:removed - ${alertId}`);
+          }
+          break;
+
+        case 'LEVEL_UP':
+        case 'LEVEL_DOWN':
+        case 'TIME_EXTENDED':
+        case 'MODIFIED':
+          if (change.current) {
+            this.io.emit('alert:updated', change.current);
+            logger.debug(`[WebSocket] Broadcast alert:updated - ${change.current.regionName} ${change.current.warningType}`);
+          }
+          break;
+      }
+    }
+
+    logger.info(`[WebSocket] Broadcasted ${changes.length} alert changes to ${this.io.engine.clientsCount} clients`);
+  }
+
+  getClientCount(): number {
+    return this.io.engine.clientsCount;
+  }
+}

--- a/src/infra/websocket/socket-server.ts
+++ b/src/infra/websocket/socket-server.ts
@@ -4,7 +4,7 @@ import { logger } from '../../utils/logger';
 import { AlertChange } from '../../types/weather';
 
 export interface SocketServerConfig {
-  readonly corsOrigin: string;
+  readonly corsOrigin?: string;
 }
 
 /**
@@ -17,7 +17,7 @@ export class SocketServer {
   constructor(httpServer: HttpServerType, config: SocketServerConfig) {
     this.io = new SocketIOServer(httpServer, {
       cors: {
-        origin: config.corsOrigin,
+        origin: config.corsOrigin ?? '*',
         methods: ['GET', 'POST'],
       },
       transports: ['websocket', 'polling'],


### PR DESCRIPTION
## Summary

기존 `server.ts`(500줄)에서 인프라 레이어를 추출하고, Zod 기반 환경변수 검증 스키마를 추가합니다.

### 인프라 레이어 (새 파일)
- `src/infra/http/middleware/request-logger.ts` — 요청 로깅
- `src/infra/http/middleware/error-handler.ts` — 에러/404 핸들러
- `src/infra/http/middleware/telegram-auth.ts` — Telegram webhook timing-safe 인증
- `src/infra/websocket/socket-server.ts` — Socket.IO 서버 + broadcastAlertChanges
- `src/infra/database/prisma-client.ts` — Prisma 싱글턴 + graceful disconnect

### Zod 환경변수 검증
- `src/config/env.schema.ts` — Zod v4 기반 스키마
  - `booleanOptIn`/`booleanOptOut` 헬퍼 (기존 의미론 유지)
  - `csvEnv` 헬퍼 (trim + filter)
  - Telegram 상호 의존 검증 (enabled 시 token/url/secret 필수)

> **Note**: 기존 `server.ts`와 `config/index.ts`는 아직 유지됩니다. Phase 6(Composition Root)에서 새 인프라 레이어로 교체 예정.

Closes #143

## 검증

- [x] `npm run build` (tsc) 통과
- [x] `npm test` 851개 테스트 통과
- [x] Codex 코드 리뷰 통과 (실질적 P1/P2: 0건, 의도된 중간상태 2건)

## 코드 리뷰 결과

- 리뷰 2회
- 1차: P2 2건(boolean 의미론, CORS fallback) + P1 2건(csv trim, Telegram 검증) → 수정
- 2차: P1 1건(Zod 미사용) + P2 1건(코드 중복) — 점진적 재작성 전략상 의도된 중간 상태, Phase 6에서 해소 예정