### PR TITLE
feat(weather): weather 모듈 분해 — RegionResolver, ForecastService, WeatherRepository (#144)

### DIFF
--- a/src/modules/weather/forecast.service.ts
+++ b/src/modules/weather/forecast.service.ts
@@ -34,6 +34,9 @@ export class ForecastService {
   private readonly vilageFcstUrl = 'https://apihub.kma.go.kr/api/typ02/openApi/VilageFcstInfoService_2.0/getVilageFcst';
 
   constructor(authKey: string, deps: ForecastServiceDeps) {
+    if (!authKey) {
+      throw new Error('WEATHER_API_KEY가 제공되지 않았습니다');
+    }
     this.authKey = authKey;
     this.getGridCoordinates = deps.getGridCoordinates;
     this.fetchWithRetry = deps.fetchWithRetry;

--- a/src/modules/weather/forecast.service.ts
+++ b/src/modules/weather/forecast.service.ts
@@ -1,0 +1,530 @@
+import { WeatherForecast, ForecastResult } from '../../types/weather';
+import { WeatherApiResponse, ForecastItem } from '../../types/api';
+import { logger } from '../../utils/logger';
+
+/**
+ * 격자 좌표 정보 (기상청 API용)
+ */
+export interface GridCoordinateInfo {
+  nx: number;
+  ny: number;
+  name: string;
+}
+
+/**
+ * ForecastService 의존성
+ */
+interface ForecastServiceDeps {
+  readonly getGridCoordinates: (regionId: string) => GridCoordinateInfo | null;
+  readonly fetchWithRetry: (url: string, options?: RequestInit, maxRetries?: number, timeout?: number) => Promise<Response>;
+  readonly getKSTNow: () => Date;
+}
+
+/**
+ * 날씨 예보 서비스
+ * 초단기예보(getUltraSrtFcst) + 단기예보(getVilageFcst) 데이터를 조회·합성
+ */
+export class ForecastService {
+  private readonly authKey: string;
+  private readonly getGridCoordinates: (regionId: string) => GridCoordinateInfo | null;
+  private readonly fetchWithRetry: (url: string, options?: RequestInit, maxRetries?: number, timeout?: number) => Promise<Response>;
+  private readonly getKSTNow: () => Date;
+
+  private readonly ultraSrtFcstUrl = 'https://apihub.kma.go.kr/api/typ02/openApi/VilageFcstInfoService_2.0/getUltraSrtFcst';
+  private readonly vilageFcstUrl = 'https://apihub.kma.go.kr/api/typ02/openApi/VilageFcstInfoService_2.0/getVilageFcst';
+
+  constructor(authKey: string, deps: ForecastServiceDeps) {
+    this.authKey = authKey;
+    this.getGridCoordinates = deps.getGridCoordinates;
+    this.fetchWithRetry = deps.fetchWithRetry;
+    this.getKSTNow = deps.getKSTNow;
+  }
+
+  /**
+   * 초단기예보 데이터 조회
+   * @param regionId 지역 코드 (특보구역 코드)
+   * @returns 날씨 예보 데이터
+   */
+  async getWeatherForecast(regionId: string): Promise<WeatherForecast | null> {
+    const result = await this.getWeatherForecastWithResult(regionId);
+    return result.data;
+  }
+
+  /**
+   * 상세 결과 포함 날씨 예보 조회
+   * 초단기예보(getUltraSrtFcst) + 단기예보(getVilageFcst) 데이터를 합성
+   */
+  async getWeatherForecastWithResult(regionId: string): Promise<ForecastResult> {
+    const startTime = Date.now();
+
+    try {
+      // 1. 격자 좌표 조회 (CSV 우선, 하드코딩 fallback)
+      const gridInfo = this.getGridCoordinates(regionId);
+      if (!gridInfo) {
+        return {
+          success: false,
+          data: null,
+          error: `지역 코드 ${regionId}에 대한 격자 좌표를 찾을 수 없습니다`
+        };
+      }
+
+      const now = this.getKSTNow();
+
+      // 2. 초단기예보 + 단기예보 병렬 호출
+      const [ultraSrtResult, vilageResult] = await Promise.allSettled([
+        this.fetchUltraSrtFcst(gridInfo, now),
+        this.fetchVilageFcst(gridInfo, now)
+      ]);
+
+      const ultraSrtData = ultraSrtResult.status === 'fulfilled' ? ultraSrtResult.value : null;
+      const vilageData = vilageResult.status === 'fulfilled' ? vilageResult.value : null;
+
+      if (!ultraSrtData && !vilageData) {
+        return {
+          success: false,
+          data: null,
+          error: '초단기예보와 단기예보 모두 조회 실패'
+        };
+      }
+
+      // 3. 데이터 합성
+      const forecast = this.mergeForecastData(ultraSrtData, vilageData, regionId, gridInfo.name);
+
+      if (!forecast) {
+        return {
+          success: false,
+          data: null,
+          error: '예보 데이터 파싱 실패'
+        };
+      }
+
+      const source = ultraSrtData && vilageData ? 'merged' as const
+        : ultraSrtData ? 'ultra-short' as const
+        : 'village' as const;
+
+      const elapsedTime = Date.now() - startTime;
+      logger.info(`지역 ${gridInfo.name}(${regionId}) 날씨 예보 조회 성공 (${source}, ${elapsedTime}ms)`);
+
+      return { success: true, data: forecast, source };
+    } catch (error) {
+      const elapsedTime = Date.now() - startTime;
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      logger.warn(`날씨 예보 조회 실패 (지역: ${regionId}, ${elapsedTime}ms): ${errorMsg}`);
+      return { success: false, data: null, error: errorMsg };
+    }
+  }
+
+  /**
+   * 초단기예보 API 호출 (getUltraSrtFcst)
+   * 1시간 단위, 매 시간 30분 발표
+   */
+  private async fetchUltraSrtFcst(
+    gridInfo: { nx: number; ny: number; name: string },
+    now: Date
+  ): Promise<ForecastItem[] | null> {
+    const { baseTime, needsPreviousDay } = this.getUltraSrtBaseTime(now);
+    const baseDateTime = needsPreviousDay ? new Date(now.getTime() - 24 * 60 * 60 * 1000) : now;
+    const baseDate = this.formatDate(baseDateTime);
+
+    const params = new URLSearchParams({
+      authKey: this.authKey,
+      base_date: baseDate,
+      base_time: baseTime,
+      nx: gridInfo.nx.toString(),
+      ny: gridInfo.ny.toString(),
+      dataType: 'JSON',
+      numOfRows: '1000',
+      pageNo: '1'
+    });
+
+    const url = `${this.ultraSrtFcstUrl}?${params.toString()}`;
+    logger.debug(`초단기예보 API 호출: base_date=${baseDate}, base_time=${baseTime}, nx=${gridInfo.nx}, ny=${gridInfo.ny}`);
+
+    return this.fetchForecastApi(url, '초단기예보');
+  }
+
+  /**
+   * 단기예보 API 호출 (getVilageFcst)
+   * 3시간 단위, 02/05/08/11/14/17/20/23시 발표
+   */
+  private async fetchVilageFcst(
+    gridInfo: { nx: number; ny: number; name: string },
+    now: Date
+  ): Promise<ForecastItem[] | null> {
+    const { baseTime, needsPreviousDay } = this.getVilageFcstBaseTime(now);
+    const baseDateTime = needsPreviousDay ? new Date(now.getTime() - 24 * 60 * 60 * 1000) : now;
+    const baseDate = this.formatDate(baseDateTime);
+
+    const params = new URLSearchParams({
+      authKey: this.authKey,
+      base_date: baseDate,
+      base_time: baseTime,
+      nx: gridInfo.nx.toString(),
+      ny: gridInfo.ny.toString(),
+      dataType: 'JSON',
+      numOfRows: '1000',
+      pageNo: '1'
+    });
+
+    const url = `${this.vilageFcstUrl}?${params.toString()}`;
+    logger.debug(`단기예보 API 호출: base_date=${baseDate}, base_time=${baseTime}, nx=${gridInfo.nx}, ny=${gridInfo.ny}`);
+
+    return this.fetchForecastApi(url, '단기예보');
+  }
+
+  /**
+   * 예보 API 공통 호출 로직
+   */
+  private async fetchForecastApi(url: string, apiName: string): Promise<ForecastItem[] | null> {
+    try {
+      const response = await this.fetchWithRetry(url);
+      if (!response.ok) {
+        logger.warn(`${apiName} API 호출 실패: ${response.status} ${response.statusText}`);
+        return null;
+      }
+
+      const responseText = await response.text();
+      let jsonData: WeatherApiResponse;
+
+      try {
+        jsonData = JSON.parse(responseText);
+      } catch {
+        if (responseText.includes('#START')) {
+          logger.warn(`${apiName} API가 텍스트 형식 응답을 반환했습니다`);
+        }
+        return null;
+      }
+
+      if (!jsonData?.response?.header || jsonData.response.header.resultCode !== '00') {
+        logger.warn(`${apiName} API 오류: ${jsonData?.response?.header?.resultMsg || 'Unknown'}`);
+        return null;
+      }
+
+      const items = jsonData.response.body?.items?.item;
+      if (!items || !Array.isArray(items) || items.length === 0) {
+        logger.warn(`${apiName} 데이터가 비어있습니다`);
+        return null;
+      }
+
+      return items;
+    } catch (error) {
+      logger.warn(`${apiName} 호출 중 오류:`, error instanceof Error ? error.message : String(error));
+      return null;
+    }
+  }
+
+  /**
+   * 초단기예보 + 단기예보 데이터를 합성
+   * 초단기예보: T1H, RN1, SKY, PTY, WSD, REH, VEC, LGT (현재 기온, 강수량 등)
+   * 단기예보: POP, TMN, TMX, T3H (강수확률, 최저/최고기온)
+   */
+  private mergeForecastData(
+    ultraSrtItems: ForecastItem[] | null,
+    vilageItems: ForecastItem[] | null,
+    regionId: string,
+    regionName: string
+  ): WeatherForecast | null {
+    // 실제 UTC 시각으로 비교 (parseForecastTime이 UTC Date를 반환하므로 일관성 유지)
+    const nowUtc = new Date();
+    const dataMap: Record<string, string> = {};
+    let baseDate = '';
+    let baseTimeStr = '';
+    let forecastTimeKey: string | null = null;
+
+    // 초단기예보 데이터 처리 (현재 기온, 풍속, 습도 등)
+    if (ultraSrtItems && ultraSrtItems.length > 0) {
+      baseDate = ultraSrtItems[0].baseDate;
+      baseTimeStr = ultraSrtItems[0].baseTime;
+
+      // 가장 가까운 미래 시간대 선택
+      const { items: selectedItems, timeKey } = this.selectNearestTimeSlice(ultraSrtItems, nowUtc);
+      if (timeKey) forecastTimeKey = timeKey;
+      for (const item of selectedItems) {
+        if (item.category && item.fcstValue !== undefined) {
+          dataMap[item.category] = item.fcstValue;
+        }
+      }
+    }
+
+    // 단기예보 데이터 처리 (POP, TMN, TMX 등 - 초단기에 없는 데이터)
+    if (vilageItems && vilageItems.length > 0) {
+      if (!baseDate) {
+        baseDate = vilageItems[0].baseDate;
+        baseTimeStr = vilageItems[0].baseTime;
+      }
+
+      // TMN/TMX는 특정 시간에만 발표되므로 전체 아이템에서 검색
+      for (const item of vilageItems) {
+        if (item.category === 'TMN' || item.category === 'TMX') {
+          if (!dataMap[item.category]) {
+            dataMap[item.category] = item.fcstValue;
+          }
+        }
+      }
+
+      // POP, T3H 등은 초단기 선택 시간대에 가장 가까운 시간대에서 추출
+      // (초단기 시간대가 있으면 그에 맞춰 정렬, 없으면 현재 시각 기준)
+      const { items: selectedVilageItems, timeKey } = forecastTimeKey
+        ? this.selectNearestTimeSlice(vilageItems, nowUtc, forecastTimeKey)
+        : this.selectNearestTimeSlice(vilageItems, nowUtc);
+      if (!forecastTimeKey && timeKey) forecastTimeKey = timeKey;
+      for (const item of selectedVilageItems) {
+        if (item.category && item.fcstValue !== undefined) {
+          // 초단기예보 데이터가 없는 카테고리만 추가
+          if (!dataMap[item.category]) {
+            dataMap[item.category] = item.fcstValue;
+          }
+        }
+      }
+    }
+
+    if (Object.keys(dataMap).length === 0) {
+      return null;
+    }
+
+    // 강수량 파싱
+    let precipitation: number | undefined;
+    if (dataMap['RN1']) {
+      const rn1 = dataMap['RN1'];
+      if (rn1 === '강수없음' || rn1.includes('강수없음')) {
+        precipitation = 0;
+      } else if (rn1.includes('1mm 미만')) {
+        precipitation = 0.1;
+      } else {
+        precipitation = this.parseNumber(rn1);
+      }
+    }
+
+    // 기온: 초단기(T1H) 우선, 없으면 단기(T3H) 사용
+    const temperature = this.parseNumber(dataMap['T1H']) ?? this.parseNumber(dataMap['T3H']);
+
+    // forecastTime: 선택된 예보 시간대의 유효 시각 (조회 시각이 아님)
+    const forecastTime = forecastTimeKey
+      ? this.parseForecastTime(forecastTimeKey)
+      : this.parseForecastTime(baseDate + baseTimeStr);
+
+    const forecast: WeatherForecast = {
+      regionId,
+      regionName,
+      baseTime: this.parseForecastTime(baseDate + baseTimeStr),
+      forecastTime,
+      temperature,
+      humidity: this.parseNumber(dataMap['REH']),
+      skyCondition: this.parseNumber(dataMap['SKY']),
+      precipitationType: this.parseNumber(dataMap['PTY']),
+      precipitation,
+      windSpeed: this.parseNumber(dataMap['WSD']),
+      windDirection: this.parseNumber(dataMap['VEC']),
+      lightningProbability: this.parseNumber(dataMap['LGT']),
+      // 단기예보 전용 데이터
+      precipitationProbability: this.parseNumber(dataMap['POP']),
+      minTemperature: this.parseNumber(dataMap['TMN']),
+      maxTemperature: this.parseNumber(dataMap['TMX']),
+    };
+
+    // 체감온도 계산
+    if (forecast.temperature !== undefined && forecast.windSpeed !== undefined) {
+      forecast.feelsLike = this.calculateFeelsLike(
+        forecast.temperature,
+        forecast.windSpeed,
+        forecast.humidity
+      );
+    }
+
+    return forecast;
+  }
+
+  /**
+   * 예보 아이템에서 가장 가까운 시간대 데이터를 선택
+   * @param items 예보 아이템 배열
+   * @param referenceUtc 비교 기준 시각 (실제 UTC Date)
+   * @param referenceTimeKey 참조 시간 키 (다른 API에서 선택된 시간대에 맞추기 위해 사용, KST YYYYMMDDHHmm)
+   * @returns 선택된 시간대의 아이템과 해당 시간 키
+   */
+  private selectNearestTimeSlice(
+    items: ForecastItem[],
+    referenceUtc: Date,
+    referenceTimeKey?: string
+  ): { items: ForecastItem[]; timeKey: string | null } {
+    const timeSlices = new Map<string, ForecastItem[]>();
+
+    for (const item of items) {
+      if (item.fcstDate && item.fcstTime) {
+        const timeKey = item.fcstDate + item.fcstTime;
+        if (!timeSlices.has(timeKey)) {
+          timeSlices.set(timeKey, []);
+        }
+        timeSlices.get(timeKey)!.push(item);
+      }
+    }
+
+    if (timeSlices.size === 0) return { items: [], timeKey: null };
+
+    const sortedTimes = Array.from(timeSlices.keys()).sort();
+
+    // referenceTimeKey가 주어진 경우: 해당 시각에 가장 가까운 시간대 선택
+    // (초단기에서 선택된 시간대에 맞춰 단기예보 시간대를 정렬)
+    if (referenceTimeKey) {
+      const refUtc = this.parseForecastTime(referenceTimeKey);
+      let bestTime = sortedTimes[0];
+      let bestDiff = Infinity;
+
+      for (const timeKey of sortedTimes) {
+        const diff = Math.abs(this.parseForecastTime(timeKey).getTime() - refUtc.getTime());
+        if (diff < bestDiff) {
+          bestDiff = diff;
+          bestTime = timeKey;
+        }
+      }
+
+      return { items: timeSlices.get(bestTime) || [], timeKey: bestTime };
+    }
+
+    // 기본: 가장 가까운 미래 시간대 선택
+    // 기본값: 가장 최근(마지막) 시간대 (모든 시간이 과거일 때)
+    let selectedTime = sortedTimes[sortedTimes.length - 1];
+
+    // parseForecastTime은 KST→UTC 변환하므로, referenceUtc (실제 UTC)와 일관된 비교 가능
+    for (const timeKey of sortedTimes) {
+      const forecastTime = this.parseForecastTime(timeKey);
+      if (forecastTime >= referenceUtc) {
+        selectedTime = timeKey;
+        break;
+      }
+    }
+
+    return { items: timeSlices.get(selectedTime) || [], timeKey: selectedTime };
+  }
+
+  /**
+   * 날짜를 YYYYMMDD 형식으로 변환
+   */
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}${month}${day}`;
+  }
+
+  /**
+   * 초단기예보 기준시각 계산
+   * 매 시간 30분에 발표되므로, 30분 이전이면 이전 시각, 30분 이후면 현재 시각
+   * @returns baseTime: 시각(HHmm), needsPreviousDay: 전날 날짜가 필요한지 여부
+   */
+  private getUltraSrtBaseTime(date: Date): { baseTime: string; needsPreviousDay: boolean } {
+    const hour = date.getHours();
+    const minute = date.getMinutes();
+
+    // 30분 이전이면 이전 시각
+    const baseHour = minute < 30 ? hour - 1 : hour;
+
+    // 0시 이전이면 23시로 (전날 날짜가 필요함)
+    const needsPreviousDay = baseHour < 0;
+    const adjustedHour = needsPreviousDay ? 23 : baseHour;
+
+    return {
+      baseTime: `${String(adjustedHour).padStart(2, '0')}30`,
+      needsPreviousDay
+    };
+  }
+
+  /**
+   * 단기예보 기준시각 계산
+   * 02:00, 05:00, 08:00, 11:00, 14:00, 17:00, 20:00, 23:00 에 발표
+   * 각 발표 시각 + ~10분 후 API에서 제공 (여유를 두어 +15분 기준)
+   */
+  getVilageFcstBaseTime(date: Date): { baseTime: string; needsPreviousDay: boolean } {
+    const hour = date.getHours();
+    const minute = date.getMinutes();
+    const currentMinutes = hour * 60 + minute;
+
+    // 발표 시각 목록 (분 단위) + API 제공 지연 15분
+    const publishTimes = [
+      { hour: 2, available: 2 * 60 + 15 },
+      { hour: 5, available: 5 * 60 + 15 },
+      { hour: 8, available: 8 * 60 + 15 },
+      { hour: 11, available: 11 * 60 + 15 },
+      { hour: 14, available: 14 * 60 + 15 },
+      { hour: 17, available: 17 * 60 + 15 },
+      { hour: 20, available: 20 * 60 + 15 },
+      { hour: 23, available: 23 * 60 + 15 },
+    ];
+
+    // 현재 시각 기준으로 가장 최근 발표 시각 찾기
+    let selectedHour = 23; // 기본값: 전날 23시
+    let needsPreviousDay = true;
+
+    for (let i = publishTimes.length - 1; i >= 0; i--) {
+      if (currentMinutes >= publishTimes[i].available) {
+        selectedHour = publishTimes[i].hour;
+        needsPreviousDay = false;
+        break;
+      }
+    }
+
+    return {
+      baseTime: `${String(selectedHour).padStart(2, '0')}00`,
+      needsPreviousDay
+    };
+  }
+
+  /**
+   * 예보 시각 문자열을 Date 객체로 변환 (KST 기준)
+   * 형식: YYYYMMDDHHmm
+   * API 응답은 KST 시간이므로 UTC로 변환하여 저장
+   */
+  private parseForecastTime(timeStr: string): Date {
+    if (!timeStr || timeStr.length < 12) {
+      return this.getKSTNow();
+    }
+
+    const year = parseInt(timeStr.substring(0, 4));
+    const month = parseInt(timeStr.substring(4, 6)) - 1;
+    const day = parseInt(timeStr.substring(6, 8));
+    const hour = parseInt(timeStr.substring(8, 10));
+    const minute = parseInt(timeStr.substring(10, 12));
+
+    // API 응답은 KST 시간(UTC+9)이므로, UTC로 변환
+    // Date.UTC는 UTC 밀리초를 반환하므로, KST에서 9시간을 빼야 함
+    const utcTime = Date.UTC(year, month, day, hour, minute) - 9 * 60 * 60 * 1000;
+    return new Date(utcTime);
+  }
+
+  /**
+   * 문자열을 숫자로 변환 (실패 시 undefined)
+   */
+  private parseNumber(value: string | undefined): number | undefined {
+    if (!value || value === '') return undefined;
+    const num = parseFloat(value);
+    return isNaN(num) ? undefined : num;
+  }
+
+  /**
+   * 체감온도 계산 (Windchill & Heat Index)
+   * @param temp 기온 (°C)
+   * @param windSpeed 풍속 (m/s)
+   * @param humidity 습도 (%)
+   */
+  private calculateFeelsLike(temp: number, windSpeed: number, humidity?: number): number {
+    // 10°C 이하: Windchill (바람찬기 지수)
+    if (temp <= 10 && windSpeed > 1.3) {
+      const windKmh = windSpeed * 3.6; // m/s -> km/h
+      const windchill = 13.12 + 0.6215 * temp - 11.37 * Math.pow(windKmh, 0.16) + 0.3965 * temp * Math.pow(windKmh, 0.16);
+      return Math.round(windchill * 10) / 10;
+    }
+
+    // 27°C 이상 + 습도 40% 이상: Heat Index (불쾌지수)
+    if (temp >= 27 && humidity !== undefined && humidity >= 40) {
+      const tempF = temp * 9 / 5 + 32; // °C -> °F
+      const heatIndex = -42.379 + 2.04901523 * tempF + 10.14333127 * humidity
+        - 0.22475541 * tempF * humidity - 0.00683783 * tempF * tempF
+        - 0.05481717 * humidity * humidity + 0.00122874 * tempF * tempF * humidity
+        + 0.00085282 * tempF * humidity * humidity - 0.00000199 * tempF * tempF * humidity * humidity;
+      const heatIndexC = (heatIndex - 32) * 5 / 9; // °F -> °C
+      return Math.round(heatIndexC * 10) / 10;
+    }
+
+    // 그 외: 실제 기온 그대로
+    return temp;
+  }
+}

--- a/src/modules/weather/index.ts
+++ b/src/modules/weather/index.ts
@@ -1,0 +1,4 @@
+export { RegionResolver } from './region-resolver';
+export type { GridCoordinateInfo } from './region-resolver';
+export { ForecastService } from './forecast.service';
+export { WeatherRepository } from './weather.repository';

--- a/src/modules/weather/region-resolver.ts
+++ b/src/modules/weather/region-resolver.ts
@@ -64,6 +64,9 @@ export class RegionResolver {
   ]);
 
   constructor(authKey: string) {
+    if (!authKey) {
+      throw new Error('WEATHER_API_KEY가 제공되지 않았습니다');
+    }
     this.authKey = authKey;
     this.loadGridCoordinatesFromCsv();
   }
@@ -681,7 +684,7 @@ export class RegionResolver {
    */
   private loadGridCoordinatesFromCsv(): void {
     try {
-      const csvPath = path.join(__dirname, '../../단기예보지점좌표(위경도)_202504.csv');
+      const csvPath = path.join(process.cwd(), '단기예보지점좌표(위경도)_202504.csv');
 
       if (!fs.existsSync(csvPath)) {
         logger.warn(`격자 좌표 CSV 파일을 찾을 수 없습니다: ${csvPath}`);

--- a/src/modules/weather/region-resolver.ts
+++ b/src/modules/weather/region-resolver.ts
@@ -1,0 +1,784 @@
+import { WeatherRegion } from '../../types/weather';
+import { logger } from '../../utils/logger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface GridCoordinateInfo {
+  nx: number;
+  ny: number;
+  name: string;
+}
+
+export class RegionResolver {
+  private readonly regionUrl = 'https://apihub.kma.go.kr/api/typ01/url/wrn_reg.php';
+  private readonly authKey: string;
+  private regionCache: Map<string, string> = new Map();
+
+  // CSV 기반 격자 좌표 캐시 (행정구역코드 → 격자 좌표)
+  private gridCoordinatesFromCsv: Map<string, GridCoordinateInfo> = new Map();
+
+  // 기상청 특보구역 코드 -> 격자 좌표 매핑
+  private readonly gridCoordinates: Map<string, GridCoordinateInfo> = new Map([
+    // 서울특별시
+    ['L1100000', { nx: 60, ny: 127, name: '서울특별시' }],
+    ['L1100100', { nx: 60, ny: 127, name: '서울동남권' }],
+    ['L1100200', { nx: 60, ny: 127, name: '서울동북권' }],
+    ['L1100300', { nx: 60, ny: 127, name: '서울서남권' }],
+    ['L1100400', { nx: 60, ny: 127, name: '서울서북권' }],
+
+    // 광역시
+    ['L1110000', { nx: 55, ny: 124, name: '인천광역시' }],
+    ['L1120000', { nx: 67, ny: 100, name: '대전광역시' }],
+    ['L1130000', { nx: 58, ny: 74, name: '광주광역시' }],
+    ['L1140000', { nx: 89, ny: 90, name: '대구광역시' }],
+    ['L1150000', { nx: 98, ny: 76, name: '부산광역시' }],
+    ['L1160000', { nx: 102, ny: 84, name: '울산광역시' }],
+    ['L1170000', { nx: 66, ny: 103, name: '세종특별자치시' }],
+
+    // 경기도
+    ['L1010000', { nx: 60, ny: 120, name: '경기도' }],
+
+    // 강원특별자치도
+    ['L1020000', { nx: 73, ny: 134, name: '강원특별자치도' }],
+
+    // 충청남도
+    ['L1030000', { nx: 55, ny: 107, name: '충청남도' }],
+
+    // 충청북도
+    ['L1040000', { nx: 69, ny: 107, name: '충청북도' }],
+
+    // 전북특별자치도
+    ['L1050000', { nx: 63, ny: 89, name: '전북특별자치도' }],
+
+    // 전라남도
+    ['L1060000', { nx: 51, ny: 67, name: '전라남도' }],
+
+    // 경상북도
+    ['L1070000', { nx: 87, ny: 106, name: '경상북도' }],
+
+    // 경상남도
+    ['L1080000', { nx: 91, ny: 77, name: '경상남도' }],
+
+    // 제주특별자치도
+    ['L1090000', { nx: 52, ny: 38, name: '제주특별자치도' }],
+  ]);
+
+  constructor(authKey: string) {
+    this.authKey = authKey;
+    this.loadGridCoordinatesFromCsv();
+  }
+
+  formatDateForAPI(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hour = String(date.getHours()).padStart(2, '0');
+    const minute = String(date.getMinutes()).padStart(2, '0');
+
+    return `${year}${month}${day}${hour}${minute}`;
+  }
+
+  async fetchRegionData(): Promise<void> {
+    try {
+      // 기상특보와 동일한 기간(7일치)으로 지역 데이터 수집
+      const periods = [
+        { days: 7, name: '최근 7일' }
+      ];
+
+      const allRegions = new Map<string, string>();
+
+      for (const period of periods) {
+        try {
+          const now = new Date();
+          const startDate = new Date(now.getTime() - period.days * 24 * 60 * 60 * 1000);
+
+          const params = {
+            tmfc1: this.formatDateForAPI(startDate),
+            tmfc2: this.formatDateForAPI(now),
+            authKey: this.authKey
+          };
+
+          const queryString = Object.entries(params)
+            .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+            .join('&');
+
+          const url = `${this.regionUrl}?${queryString}`;
+          logger.debug(`특보구역 API 호출 (${period.name}): ${url}`);
+
+          const response = await fetch(url);
+          if (!response.ok) {
+            const errorText = await response.text();
+            logger.debug(`특보구역 API 호출 실패 (${period.name}): ${response.status} ${response.statusText} - ${errorText}`);
+            continue; // 다음 기간으로 계속
+          }
+
+          const responseText = await response.text();
+
+          if (!responseText.trim().startsWith('#START')) {
+            logger.debug(`특보구역 API 응답 형식 오류 (${period.name}): ${responseText.substring(0, 100)}`);
+            continue;
+          }
+
+          const regions = this.parseRegionCSVResponse(responseText);
+
+          // 지역 데이터를 통합 맵에 추가
+          regions.forEach(region => {
+            if (region.REG_NAME && region.REG_NAME.trim() !== '') {
+              allRegions.set(region.REG_ID, region.REG_NAME);
+            }
+          });
+
+          logger.debug(`${period.name} 기간에서 ${regions.length}개 지역 데이터 수집`);
+
+          // 짧은 지연 후 다음 요청
+          await new Promise(resolve => setTimeout(resolve, 500));
+
+        } catch (error) {
+          logger.debug(`특보구역 데이터 수집 중 오류 (${period.name}):`, error);
+          continue;
+        }
+      }
+
+      // 캐시에 저장
+      this.regionCache.clear();
+      allRegions.forEach((name, id) => {
+        this.regionCache.set(id, name);
+      });
+
+      logger.info(`총 ${allRegions.size}개 특보구역 데이터 로드 완료`);
+
+      // 수집된 지역 데이터 샘플 로그
+      const sampleRegions = Array.from(allRegions.entries()).slice(0, 10);
+      logger.debug('수집된 지역 데이터 샘플:', sampleRegions);
+
+    } catch (error) {
+      logger.error('특보구역 데이터 로드 중 오류:', error);
+    }
+  }
+
+  private parseRegionCSVResponse(responseText: string): WeatherRegion[] {
+    const lines = responseText.split('\n');
+    const regions: WeatherRegion[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith('#') || line.trim() === '' || !line.includes(',')) {
+        continue;
+      }
+
+      try {
+        // CSV 형식: REG_ID, TM_ST, TM_ED, REG_SP, REG_UP, REG_KO, REG_NAME, =
+        const fields = line.split(',').map(field => field.trim());
+
+        if (fields.length >= 7) {
+          const region: WeatherRegion = {
+            REG_ID: fields[0],
+            TM_ST: fields[1],
+            TM_ED: fields[2],
+            REG_SP: fields[3],
+            REG_UP: fields[4],
+            REG_KO: fields[5],
+            REG_NAME: fields[6]
+          };
+
+          regions.push(region);
+        }
+      } catch (error) {
+        logger.debug(`특보구역 CSV 라인 파싱 오류: ${line}`);
+      }
+    }
+
+    return regions;
+  }
+
+  /**
+   * 지역 코드의 상위 지역명을 반환합니다.
+   * manualRegionMapping에 있는 실제 상위 지역을 찾을 때까지 재귀적으로 탐색합니다.
+   * @param regId 지역 코드 (예: S1311200)
+   * @returns 상위 지역명 (예: 남해동부앞바다)
+   */
+  getUpperRegionName(regId: string): string {
+    if (!regId || regId.length !== 8) {
+      return '';
+    }
+
+    // Codex P1 피드백 반영: 먼저 현재 지역이 이미 광역시/도 단위인지 확인
+    const currentName = this.getRegionName(regId);
+
+    // 특수 코드 처리: 울릉도.독도는 경상북도로 매핑
+    if (currentName === '울릉도.독도') {
+      return '경상북도';
+    }
+
+    // 현재 지역이 실제 매핑이고 (fallback이 아니고)
+    const isRealMapping = !currentName.startsWith('육상지역(') && !currentName.startsWith('해상지역(');
+
+    // 광역시/도 단위면 자기 자신을 그룹으로 반환
+    // endsWith로 정확히 체크 (예: "제주도", "흑산도" 같은 일반 지역 제외)
+    // 주의: "앞바다"/"먼바다"는 여기서 체크하지 않음 (하위 지역도 "앞바다"로 끝날 수 있음)
+    const isTopLevelGroup = currentName.endsWith('특별시') ||
+                            currentName.endsWith('광역시') ||
+                            currentName.endsWith('도') ||
+                            currentName.endsWith('특별자치시') ||
+                            currentName.endsWith('전해상') ||
+                            // Codex P1 피드백 #2: 특수 최상위 지역 처리
+                            currentName === '전국' ||
+                            currentName === '전해상' ||
+                            currentName.includes('연안바다') ||
+                            currentName.includes('평수구역');
+
+    if (isRealMapping && isTopLevelGroup) {
+      return currentName;
+    }
+
+    // 지역 코드 계층 구조 분석
+    // 예: S1311200 → S1311000 (상위 지역)
+    //     S1311000 → S1310000
+    //     S1310000 → S1300000
+    //     S1300000 → S1000000
+
+    const prefix = regId[0]; // L 또는 S
+    const digits = regId.substring(1); // 7자리 숫자
+
+    // 뒤에서부터 연속된 0의 개수를 세어 현재 레벨 파악
+    let level = 0;
+    for (let i = digits.length - 1; i >= 0; i--) {
+      if (digits[i] === '0') {
+        level++;
+      } else {
+        break;
+      }
+    }
+
+    // 최상위 레벨 (6개 이상의 0) 또는 매핑되지 않은 코드
+    // Codex P1 피드백 #3: "기타" fallback 복원
+    if (level >= 6) {
+      return '기타';
+    }
+
+    // 상위 지역 코드 생성: 한 자리 더 0으로 만들기
+    // 예: S1311200 (level 2) → S1311000 (level 3)
+    //     S1311000 (level 3) → S1310000 (level 4)
+    const nonZeroLength = 7 - level; // 0이 아닌 부분의 길이
+    const parentDigits = digits.substring(0, nonZeroLength - 1) + '0'.repeat(level + 1);
+    const parentRegId = prefix + parentDigits;
+
+    // 상위 지역명 조회
+    const parentName = this.getRegionName(parentRegId);
+
+    // 상위 지역이 실제 매핑이고 (fallback이 아니고)
+    const isParentRealMapping = !parentName.startsWith('육상지역(') && !parentName.startsWith('해상지역(');
+
+    // 광역시/도 단위 또는 해상 그룹핑 단위면 반환
+    const isParentTopLevel = parentName.endsWith('특별시') ||
+                             parentName.endsWith('광역시') ||
+                             parentName.endsWith('도') ||
+                             parentName.endsWith('특별자치시') ||
+                             parentName.endsWith('전해상') ||
+                             // Codex P1 피드백 #4: 해상 중간 그룹핑 단위 추가
+                             parentName.endsWith('앞바다') ||
+                             parentName.endsWith('먼바다') ||
+                             // Codex P1 피드백 #2: 특수 최상위 지역 처리
+                             parentName === '전국' ||
+                             parentName === '전해상' ||
+                             parentName.includes('연안바다') ||
+                             parentName.includes('평수구역');
+
+    if (isParentRealMapping && isParentTopLevel) {
+      return parentName;
+    }
+
+    // 아니면 계속 상위로 올라가서 광역시/도 단위를 찾음
+    return this.getUpperRegionName(parentRegId);
+  }
+
+  getRegionName(regId: string): string {
+    // 먼저 캐시에서 찾기
+    const cachedName = this.regionCache.get(regId);
+    if (cachedName) {
+      return cachedName;
+    }
+
+    // area_code.md 기반 완전한 지역 매핑 (모든 지역 코드 포함)
+    const manualRegionMapping: Record<string, string> = {
+      // === 육상지역 (L) ===
+      // 전국
+      'L1000000': '전국',
+
+      // 경기도
+      'L1010000': '경기도',
+      'L1010200': '광명시',
+      'L1010300': '과천시',
+      'L1010400': '안산시',
+      'L1010500': '시흥시',
+      'L1010600': '부천시',
+      'L1010700': '김포시',
+      'L1010800': '인천광역시',
+      'L1010900': '강화군',
+      'L1011100': '동두천시',
+      'L1011200': '연천군',
+      'L1011300': '포천시',
+      'L1011400': '가평군',
+      'L1011500': '고양시',
+      'L1011600': '양주시',
+      'L1011700': '의정부시',
+      'L1011800': '파주시',
+      'L1011900': '수원시',
+      'L1012000': '성남시',
+      'L1012100': '안양시',
+      'L1012200': '구리시',
+      'L1012300': '남양주시',
+      'L1012400': '오산시',
+      'L1012500': '평택시',
+      'L1012600': '군포시',
+      'L1012700': '의왕시',
+      'L1012800': '하남시',
+      'L1012900': '용인시',
+      'L1013000': '이천시',
+      'L1013100': '안성시',
+      'L1013200': '화성시',
+      'L1013300': '여주시',
+      'L1013400': '광주시',
+      'L1013500': '양평군',
+      'L1013600': '옹진군',
+      'L1014000': '서해5도',
+      'L1014100': '서해5도',
+
+      // 강원도
+      'L1020000': '강원도',
+      'L1020110': '강릉시평지',
+      'L1020210': '동해시평지',
+      'L1020300': '태백시',
+      'L1020410': '삼척시평지',
+      'L1020510': '속초시평지',
+      'L1020610': '고성군평지',
+      'L1020710': '양양군평지',
+      'L1020800': '영월군',
+      'L1020910': '평창군평지',
+      'L1021010': '정선군평지',
+      'L1021100': '횡성군',
+      'L1021200': '원주시',
+      'L1021300': '철원군',
+      'L1021400': '화천군',
+      'L1021510': '홍천군평지',
+      'L1021600': '춘천시',
+      'L1021710': '양구군평지',
+      'L1021810': '인제군평지',
+      'L1025020': '강원북부산지',
+      'L1026020': '강원중부산지',
+      'L1027020': '강원남부산지',
+
+      // 충청남도
+      'L1030000': '충청남도',
+      'L1030100': '대전광역시',
+      'L1030200': '천안시',
+      'L1030300': '공주시',
+      'L1030400': '아산시',
+      'L1030500': '논산시',
+      'L1030600': '금산군',
+      'L1030800': '부여군',
+      'L1030900': '청양군',
+      'L1031000': '예산군',
+      'L1031100': '태안군',
+      'L1031200': '당진시',
+      'L1031300': '서산시',
+      'L1031400': '보령시',
+      'L1031500': '서천군',
+      'L1031600': '홍성군',
+      'L1031700': '계룡시',
+      'L1031800': '세종특별자치시',
+
+      // 충청북도
+      'L1040000': '충청북도',
+      'L1040100': '청주시',
+      'L1040300': '보은군',
+      'L1040400': '괴산군',
+      'L1040600': '옥천군',
+      'L1040700': '영동군',
+      'L1040800': '충주시',
+      'L1040900': '제천시',
+      'L1041000': '진천군',
+      'L1041100': '음성군',
+      'L1041200': '단양군',
+      'L1041300': '증평군',
+
+      // 전라남도
+      'L1050000': '전라남도',
+      'L1050100': '광주광역시',
+      'L1050200': '나주시',
+      'L1050300': '담양군',
+      'L1050400': '곡성군',
+      'L1050500': '구례군',
+      'L1050600': '장성군',
+      'L1050700': '화순군',
+      'L1050800': '고흥군',
+      'L1050900': '보성군',
+      'L1051000': '여수시',
+      'L1051100': '광양시',
+      'L1051200': '순천시',
+      'L1051300': '장흥군',
+      'L1051400': '강진군',
+      'L1051500': '해남군',
+      'L1051600': '완도군',
+      'L1051700': '영암군',
+      'L1051800': '무안군',
+      'L1051900': '함평군',
+      'L1052000': '영광군',
+      'L1052100': '목포시',
+      'L1052200': '신안군(흑산면제외)',
+      'L1052300': '진도군',
+      'L1052400': '흑산도.홍도',
+      'L1052500': '흑산도.홍도',
+      'L1052600': '거문도.초도',
+
+      // 전북자치도
+      'L1060000': '전북자치도',
+      'L1060100': '고창군',
+      'L1060200': '부안군',
+      'L1060300': '군산시',
+      'L1060400': '김제시',
+      'L1060500': '완주군',
+      'L1060600': '진안군',
+      'L1060700': '무주군',
+      'L1060800': '장수군',
+      'L1060900': '임실군',
+      'L1061000': '순창군',
+      'L1061100': '익산시',
+      'L1061200': '정읍시',
+      'L1061300': '전주시',
+      'L1061400': '남원시',
+
+      // 경상북도
+      'L1070000': '경상북도',
+      'L1070100': '대구광역시',
+      'L1070200': '군위군',
+      'L1070300': '구미시',
+      'L1070400': '영천시',
+      'L1070500': '경산시',
+      'L1070700': '청도군',
+      'L1070800': '고령군',
+      'L1070900': '성주군',
+      'L1071000': '칠곡군',
+      'L1071100': '김천시',
+      'L1071200': '상주시',
+      'L1071300': '문경시',
+      'L1071400': '예천군',
+      'L1071500': '안동시',
+      'L1071600': '영주시',
+      'L1071700': '의성군',
+      'L1071800': '청송군',
+      'L1071910': '영양군평지',
+      'L1072010': '봉화군평지',
+      'L1072100': '울릉도.독도',
+      'L1072200': '영덕군',
+      'L1072310': '울진군평지',
+      'L1072400': '포항시',
+      'L1072500': '경주시',
+      'L1075020': '경북북동산지',
+
+      // 경상남도
+      'L1080000': '경상남도',
+      'L1080500': '양산시',
+      'L1080600': '창원시',
+      'L1080900': '김해시',
+      'L1081000': '밀양시',
+      'L1081100': '의령군',
+      'L1081200': '함안군',
+      'L1081300': '창녕군',
+      'L1081400': '진주시',
+      'L1081500': '하동군',
+      'L1081600': '산청군',
+      'L1081700': '함양군',
+      'L1081800': '거창군',
+      'L1081900': '합천군',
+      'L1082000': '통영시',
+      'L1082100': '사천시',
+      'L1082200': '거제시',
+      'L1082300': '고성군',
+      'L1082400': '남해군',
+      'L1082500': '부산동부',
+      'L1082600': '부산중부',
+      'L1082700': '부산서부',
+      'L1082800': '울산동부',
+      'L1082900': '울산서부',
+
+      // 제주도
+      'L5010000': '제주도',  // 제주특별자치도 (상위 코드)
+      'L1090000': '제주도',
+      'L1090500': '제주도산지',
+      'L1090600': '제주도서부',
+      'L1090700': '제주도북부',
+      'L1090800': '제주도동부',
+      'L1090900': '제주도남부',
+      'L1091000': '추자도',
+      'L1091100': '제주도북부중산간',
+      'L1091200': '제주도남부중산간',
+
+      // 서울특별시
+      'L1100000': '서울특별시',
+      'L1100100': '서울동남권',
+      'L1100200': '서울동북권',
+      'L1100300': '서울서남권',
+      'L1100400': '서울서북권',
+
+      // 광역시/특별시/자치시
+      'L1110000': '인천광역시',
+      'L1120000': '대전광역시',
+      'L1130000': '광주광역시',
+      'L1140000': '대구광역시',
+      'L1150000': '부산광역시',
+      'L1160000': '울산광역시',
+      'L1170000': '세종특별자치시',
+      'L1600000': '울릉도.독도',
+
+      // === 해상지역 (S) ===
+      // 전해상
+      'S1000000': '전해상',
+
+      // 동해전해상
+      'S1100000': '동해전해상',
+
+      // 동해남부전해상
+      'S1130000': '동해남부전해상',
+      'S1131000': '동해남부앞바다',
+      'S1131100': '울산앞바다',
+      'S1131200': '경북남부앞바다',
+      'S1131300': '경북북부앞바다',
+      'S1132110': '동해남부남쪽안쪽먼바다',
+      'S1132120': '동해남부남쪽바깥먼바다',
+      'S1132210': '동해남부북쪽안쪽먼바다',
+      'S1132220': '동해남부북쪽바깥먼바다',
+
+      // 동해중부전해상
+      'S1150000': '동해중부전해상',
+      'S1151000': '동해중부앞바다',
+      'S1151100': '강원북부앞바다',
+      'S1151200': '강원중부앞바다',
+      'S1151300': '강원남부앞바다',
+      'S1152010': '동해중부안쪽먼바다',
+      'S1152020': '동해중부바깥먼바다',
+
+      // 서해전해상
+      'S1200000': '서해전해상',
+
+      // 서해남부전해상
+      'S1230000': '서해남부전해상',
+      'S1231000': '서해남부앞바다',
+      'S1231100': '전북북부앞바다',
+      'S1231200': '전북남부앞바다',
+      'S1231300': '전남북부서해앞바다',
+      'S1231400': '전남중부서해앞바다',
+      'S1231500': '전남남부서해앞바다',
+      'S1232110': '서해남부북쪽안쪽먼바다',
+      'S1232120': '서해남부북쪽바깥먼바다',
+      'S1232210': '서해남부남쪽안쪽먼바다',
+      'S1232220': '서해남부남쪽바깥먼바다',
+
+      // 서해중부전해상
+      'S1250000': '서해중부전해상',
+      'S1251000': '서해중부앞바다',
+      'S1251100': '인천·경기북부앞바다',
+      'S1251200': '인천·경기남부앞바다',
+      'S1251300': '충남북부앞바다',
+      'S1251400': '충남남부앞바다',
+      'S1252010': '서해중부안쪽먼바다',
+      'S1252020': '서해중부바깥먼바다',
+
+      // 남해전해상
+      'S1300000': '남해전해상',
+
+      // 남해동부전해상
+      'S1310000': '남해동부전해상',
+      'S1311000': '남해동부앞바다',
+      'S1311100': '부산앞바다',
+      'S1311200': '경남서부남해앞바다',
+      'S1311300': '경남중부남해앞바다',
+      'S1311400': '거제시동부앞바다',
+      'S1312010': '남해동부안쪽먼바다',
+      'S1312020': '남해동부바깥먼바다',
+
+      // 남해서부전해상
+      'S1320000': '남해서부전해상',
+      'S1321000': '남해서부앞바다',
+      'S1321100': '전남서부남해앞바다',
+      'S1321200': '전남동부남해앞바다',
+      'S1322100': '남해서부서쪽먼바다',
+      'S1322200': '남해서부동쪽먼바다',
+
+      // 제주도해상
+      'S1323000': '제주도앞바다',
+      'S1323100': '제주도북부앞바다',
+      'S1323200': '제주도동부앞바다',
+      'S1323300': '제주도남부앞바다',
+      'S1323400': '제주도서부앞바다',
+      'S1324020': '제주도남쪽바깥먼바다',
+      'S1324110': '제주도남동쪽안쪽먼바다',
+      'S1324210': '제주도남서쪽안쪽먼바다',
+      'S1330000': '제주도전해상',
+
+      // 연안바다/평수구역 (일부 주요지역만)
+      'S2000000': '연안바다/평수구역'
+    };
+
+    // 수동 매핑에서 찾기
+    if (manualRegionMapping[regId]) {
+      return manualRegionMapping[regId];
+    }
+
+    // 패턴 기반 기본 처리
+    if (regId.startsWith('L')) {
+      return `육상지역(${regId})`;
+    }
+
+    if (regId.startsWith('S')) {
+      return `해상지역(${regId})`;
+    }
+
+    return regId;
+  }
+
+  /**
+   * 한국 표준시(KST, UTC+9) 기준 현재 시간 반환
+   * 서버가 UTC나 다른 시간대에서 실행되더라도 KST 시간을 정확히 계산
+   */
+  getKSTNow(): Date {
+    const now = new Date();
+    // 현재 시간을 UTC 기준으로 변환
+    const utcMillis = now.getTime() + (now.getTimezoneOffset() * 60 * 1000);
+    // UTC에 9시간(KST 오프셋) 추가
+    const kstMillis = utcMillis + (9 * 60 * 60 * 1000);
+    return new Date(kstMillis);
+  }
+
+  /**
+   * 하위 지역 코드를 광역시도 코드로 변환
+   * @param regionId 지역 코드 (예: L1100510)
+   * @returns 광역시도 코드 (예: L1100000)
+   */
+  getUpperRegionCode(regionId: string): string {
+    // 이미 gridCoordinates에 있으면 그대로 반환
+    if (this.gridCoordinates.has(regionId)) {
+      return regionId;
+    }
+
+    // L로 시작하는 8자리 이상 코드면 광역시도 코드로 변환
+    // 예: L1100510 → L1100000, L1010100 → L1010000
+    if (regionId.startsWith('L') && regionId.length >= 8) {
+      const upperCode = regionId.substring(0, 5) + '000';
+      if (this.gridCoordinates.has(upperCode)) {
+        logger.debug(`지역 코드 ${regionId}를 광역시도 코드 ${upperCode}로 매핑`);
+        return upperCode;
+      }
+    }
+
+    // 찾지 못하면 원본 반환
+    return regionId;
+  }
+
+  /**
+   * CSV 파일에서 격자 좌표 데이터 로드
+   * 파일: 단기예보지점좌표(위경도)_202504.csv
+   * 형식: 구분,행정구역코드,1단계,2단계,3단계,격자 X,격자 Y,경도(시),경도(분),경도(초),위도(시),위도(분),위도(초),경도(초/100),위도(초/100),위치업데이트
+   */
+  private loadGridCoordinatesFromCsv(): void {
+    try {
+      const csvPath = path.join(__dirname, '../../단기예보지점좌표(위경도)_202504.csv');
+
+      if (!fs.existsSync(csvPath)) {
+        logger.warn(`격자 좌표 CSV 파일을 찾을 수 없습니다: ${csvPath}`);
+        logger.warn('하드코딩된 광역시도 좌표만 사용됩니다.');
+        return;
+      }
+
+      const csvContent = fs.readFileSync(csvPath, 'utf-8');
+      const lines = csvContent.split('\n');
+      let loadedCount = 0;
+
+      // 첫 번째 라인은 헤더이므로 스킵
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        const fields = line.split(',');
+        if (fields.length < 7) continue;
+
+        const adminCode = fields[1].trim(); // 행정구역코드 (10자리 숫자)
+        const region1 = fields[2].trim();   // 1단계 (시/도)
+        const region2 = fields[3].trim();   // 2단계 (시/군/구)
+        const region3 = fields[4].trim();   // 3단계 (읍/면/동)
+        const nx = parseInt(fields[5].trim(), 10);
+        const ny = parseInt(fields[6].trim(), 10);
+
+        if (isNaN(nx) || isNaN(ny) || !adminCode) continue;
+
+        // 지역명 조합
+        let name = region1;
+        if (region2) name += ` ${region2}`;
+        if (region3) name += ` ${region3}`;
+
+        // 행정구역코드를 그대로 키로 사용
+        this.gridCoordinatesFromCsv.set(adminCode, { nx, ny, name });
+        loadedCount++;
+      }
+
+      logger.info(`CSV 파일에서 ${loadedCount}개 지역의 격자 좌표를 로드했습니다.`);
+    } catch (error) {
+      logger.error('CSV 파일 로드 중 오류:', error);
+      logger.warn('하드코딩된 광역시도 좌표만 사용됩니다.');
+    }
+  }
+
+  /**
+   * REG_ID를 행정구역코드로 변환
+   * @param regionId 특보구역 코드 (예: L1100000, L1100510)
+   * @returns 행정구역코드 (10자리, 예: 1100000000)
+   */
+  private convertRegIdToAdminCode(regionId: string): string | null {
+    // L로 시작하는 8자리 코드
+    if (!regionId.startsWith('L') || regionId.length < 8) {
+      logger.warn(`잘못된 지역 코드 형식: ${regionId}`);
+      return null;
+    }
+
+    // L 제거 (L1100000 → 1100000)
+    const numericPart = regionId.substring(1);
+
+    // 7자리 숫자 뒤에 000 추가 (1100000 → 1100000000)
+    const adminCode = numericPart + '000';
+
+    return adminCode;
+  }
+
+  /**
+   * 격자 좌표 조회 (CSV 우선, 하드코딩 fallback)
+   * @param regionId 특보구역 코드 (예: L1100000)
+   * @returns 격자 좌표 정보
+   */
+  getGridCoordinates(regionId: string): GridCoordinateInfo | null {
+    // 1. 행정구역코드로 변환
+    const adminCode = this.convertRegIdToAdminCode(regionId);
+
+    // 2. CSV에서 조회 (우선)
+    if (adminCode && this.gridCoordinatesFromCsv.has(adminCode)) {
+      const gridInfo = this.gridCoordinatesFromCsv.get(adminCode)!;
+      logger.debug(`CSV에서 격자 좌표 조회 성공: ${regionId} → ${adminCode} → (${gridInfo.nx}, ${gridInfo.ny})`);
+      return gridInfo;
+    }
+
+    // 3. 하드코딩된 광역시도 좌표에서 조회 (fallback)
+    if (this.gridCoordinates.has(regionId)) {
+      const gridInfo = this.gridCoordinates.get(regionId)!;
+      logger.debug(`하드코딩 좌표 조회 성공: ${regionId} → (${gridInfo.nx}, ${gridInfo.ny})`);
+      return gridInfo;
+    }
+
+    // 4. 상위 지역 코드로 재시도
+    const upperRegionId = this.getUpperRegionCode(regionId);
+    if (upperRegionId !== regionId) {
+      logger.debug(`상위 지역 코드로 재시도: ${regionId} → ${upperRegionId}`);
+      return this.getGridCoordinates(upperRegionId);
+    }
+
+    logger.warn(`지역 코드 ${regionId}에 대한 격자 좌표를 찾을 수 없습니다`);
+    return null;
+  }
+}

--- a/src/modules/weather/weather.repository.ts
+++ b/src/modules/weather/weather.repository.ts
@@ -1,0 +1,297 @@
+import { PrismaClient } from '@prisma/client';
+import { AlertChange, AlertChangeType, CachedAlert, WeatherAlert } from '../../types/weather';
+import { logger } from '../../utils/logger';
+
+/**
+ * 기상특보 Repository
+ * Prisma를 통해 WeatherAlert, AlertHistory 테이블에 접근
+ */
+export class WeatherRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * 특보 데이터 upsert (같은 지역+특보종류 → 업데이트)
+   */
+  async saveWeatherAlert(alert: WeatherAlert): Promise<void> {
+    try {
+      const data = {
+        regionId: alert.REG_ID,
+        regionName: alert.REG_NAME,
+        upperRegion: alert.upperRegion || null,
+        warningType: alert.WRN,
+        warningLevel: alert.LVL,
+        command: alert.CMD,
+        announcedAt: new Date(alert.TM_FC),
+        effectiveAt: new Date(alert.TM_EF),
+        endTime: alert.TM_ED ? new Date(alert.TM_ED) : null,
+      };
+
+      await this.prisma.weatherAlert.upsert({
+        where: {
+          regionId_warningType: {
+            regionId: alert.REG_ID,
+            warningType: alert.WRN,
+          },
+        },
+        update: { ...data, updatedAt: new Date() },
+        create: data,
+      });
+
+      logger.debug(`특보 저장 완료: ${alert.REG_NAME} ${alert.WRN}`);
+    } catch (error) {
+      logger.error('특보 저장 실패:', {
+        regionId: alert.REG_ID,
+        warningType: alert.WRN,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 여러 특보 일괄 저장
+   */
+  async saveWeatherAlerts(alerts: WeatherAlert[]): Promise<void> {
+    await Promise.all(alerts.map(alert => this.saveWeatherAlert(alert)));
+    logger.info(`${alerts.length}개 특보 일괄 저장 완료`);
+  }
+
+  /**
+   * 특보 변동 이력 저장
+   */
+  async saveAlertHistory(change: AlertChange): Promise<void> {
+    const alert = change.current || change.previous!;
+
+    if (!alert.regionId || !alert.regionName || !alert.warningType || !alert.level) {
+      throw new Error(`AlertHistory 저장 실패 - 필수 필드 누락: ${JSON.stringify({
+        regionId: alert.regionId,
+        regionName: alert.regionName,
+        warningType: alert.warningType,
+        level: alert.level,
+        changeType: change.type,
+      })}`);
+    }
+
+    await this.prisma.alertHistory.create({
+      data: {
+        regionId: alert.regionId,
+        regionName: alert.regionName,
+        upperRegion: alert.upperRegion || null,
+        warningType: alert.warningType,
+        warningLevel: alert.level,
+        changeType: change.type,
+        previousData: change.previous ? JSON.parse(JSON.stringify(change.previous)) : null,
+        currentData: change.current ? JSON.parse(JSON.stringify(change.current)) : null,
+      },
+    });
+
+    logger.debug(`특보 이력 저장 완료: ${alert.regionName} ${change.type}`);
+  }
+
+  /**
+   * 여러 특보 이력 일괄 저장
+   */
+  async saveAlertHistories(changes: AlertChange[]): Promise<void> {
+    await Promise.all(changes.map(change => this.saveAlertHistory(change)));
+    logger.info(`${changes.length}개 특보 이력 일괄 저장 완료`);
+  }
+
+  /**
+   * CachedAlert → DB 동기화
+   * 캐시에 있는 특보는 upsert, 없는 특보는 해제 처리
+   */
+  async syncCachedAlerts(cachedAlerts: CachedAlert[]): Promise<void> {
+    // 활성 특보 upsert
+    if (cachedAlerts.length > 0) {
+      await Promise.all(cachedAlerts.map(async (alert) => {
+        const announcedAt = this.parseKmaTimestamp(alert.announcedAt);
+        const effectiveAt = this.parseKmaTimestamp(alert.effectiveAt);
+        const endTime = alert.endTime ? this.parseKmaTimestamp(alert.endTime) : null;
+
+        await this.prisma.weatherAlert.upsert({
+          where: {
+            regionId_warningType: {
+              regionId: alert.regionId,
+              warningType: alert.warningType,
+            },
+          },
+          update: {
+            regionName: alert.regionName,
+            upperRegion: alert.upperRegion || null,
+            warningLevel: alert.level,
+            command: alert.command,
+            announcedAt,
+            effectiveAt,
+            endTime,
+            updatedAt: new Date(),
+          },
+          create: {
+            regionId: alert.regionId,
+            regionName: alert.regionName,
+            upperRegion: alert.upperRegion || null,
+            warningType: alert.warningType,
+            warningLevel: alert.level,
+            command: alert.command,
+            announcedAt,
+            effectiveAt,
+            endTime,
+          },
+        });
+      }));
+    }
+
+    // 캐시에 없는 특보 해제 처리
+    const resolvedCondition = cachedAlerts.length > 0
+      ? {
+          NOT: {
+            OR: cachedAlerts.map(a => ({
+              AND: [{ regionId: a.regionId }, { warningType: a.warningType }],
+            })),
+          },
+          command: { notIn: ['3', '4', '7'] },
+        }
+      : { command: { notIn: ['3', '4', '7'] } };
+
+    const result = await this.prisma.weatherAlert.updateMany({
+      where: resolvedCondition,
+      data: { command: '3', updatedAt: new Date() },
+    });
+
+    logger.debug(`캐시 특보 동기화 완료: ${cachedAlerts.length}개 활성, ${result.count}개 해제`);
+  }
+
+  /**
+   * 현재 활성 특보 조회
+   */
+  async getCurrentAlerts(filters?: {
+    regionId?: string;
+    warningType?: string;
+    warningLevel?: string;
+    upperRegion?: string;
+  }): Promise<unknown[]> {
+    const alerts = await this.prisma.weatherAlert.findMany({
+      where: {
+        regionId: filters?.regionId,
+        warningType: filters?.warningType,
+        warningLevel: filters?.warningLevel,
+        upperRegion: filters?.upperRegion,
+        command: { notIn: ['3', '4', '7'] },
+      },
+      orderBy: { announcedAt: 'desc' },
+    });
+
+    logger.debug(`현재 특보 조회: ${alerts.length}건`);
+    return alerts;
+  }
+
+  /**
+   * 특보 이력 조회 (기간별)
+   */
+  async getAlertHistory(filters: {
+    startDate: Date;
+    endDate: Date;
+    regionId?: string;
+    warningType?: string;
+    changeType?: AlertChangeType;
+  }): Promise<unknown[]> {
+    const histories = await this.prisma.alertHistory.findMany({
+      where: {
+        timestamp: { gte: filters.startDate, lte: filters.endDate },
+        regionId: filters.regionId,
+        warningType: filters.warningType,
+        changeType: filters.changeType,
+      },
+      orderBy: { timestamp: 'desc' },
+    });
+
+    logger.debug(`특보 이력 조회: ${histories.length}건`);
+    return histories;
+  }
+
+  /**
+   * 특보 통계 (groupBy)
+   */
+  async getAlertStatistics(filters: {
+    startDate: Date;
+    endDate: Date;
+    groupBy: 'region' | 'warningType' | 'level';
+  }): Promise<Record<string, unknown>[]> {
+    type GroupByField = 'upperRegion' | 'warningType' | 'warningLevel';
+    const groupByMap: Record<string, GroupByField> = {
+      region: 'upperRegion',
+      warningType: 'warningType',
+      level: 'warningLevel',
+    };
+    const groupByKey = groupByMap[filters.groupBy];
+
+    const stats = await this.prisma.alertHistory.groupBy({
+      by: [groupByKey],
+      where: {
+        timestamp: { gte: filters.startDate, lte: filters.endDate },
+        changeType: 'NEW',
+      },
+      _count: { id: true },
+      orderBy: { _count: { id: 'desc' } },
+    });
+
+    logger.debug(`특보 통계 조회: ${stats.length}건`);
+    return stats;
+  }
+
+  /**
+   * 오래된 이력 정리
+   */
+  async cleanupOldData(retentionDays: number = 365): Promise<number> {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+    const result = await this.prisma.alertHistory.deleteMany({
+      where: { timestamp: { lt: cutoffDate } },
+    });
+
+    logger.info(`${result.count}개 오래된 이력 데이터 삭제 (${retentionDays}일 이전)`);
+    return result.count;
+  }
+
+  /**
+   * 지역 매핑 저장
+   */
+  async saveRegionMapping(regionId: string, regionName: string, upperRegion: string): Promise<void> {
+    await this.prisma.regionMapping.upsert({
+      where: { regionId },
+      update: { regionName, upperRegion },
+      create: { regionId, regionName, upperRegion },
+    });
+  }
+
+  /**
+   * 지역 매핑 조회
+   */
+  async getRegionMapping(regionId: string): Promise<unknown | null> {
+    return this.prisma.regionMapping.findUnique({ where: { regionId } });
+  }
+
+  /**
+   * KMA 타임스탬프(YYYYMMDDHHmm) → Date
+   */
+  private parseKmaTimestamp(kmaTimestamp: string): Date {
+    if (!kmaTimestamp || kmaTimestamp.length !== 12 || !/^\d{12}$/.test(kmaTimestamp)) {
+      throw new Error(`Invalid KMA timestamp format: ${kmaTimestamp}`);
+    }
+
+    const year = kmaTimestamp.substring(0, 4);
+    const month = kmaTimestamp.substring(4, 6);
+    const day = kmaTimestamp.substring(6, 8);
+    const hour = kmaTimestamp.substring(8, 10);
+    const minute = kmaTimestamp.substring(10, 12);
+
+    const isoString = `${year}-${month}-${day}T${hour}:${minute}:00+09:00`;
+    const date = new Date(isoString);
+
+    if (isNaN(date.getTime())) {
+      throw new Error(`Invalid date from KMA timestamp: ${kmaTimestamp}`);
+    }
+
+    return date;
+  }
+}

--- a/src/modules/weather/weather.repository.ts
+++ b/src/modules/weather/weather.repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, WeatherAlert as PrismaWeatherAlert, AlertHistory as PrismaAlertHistory, RegionMapping as PrismaRegionMapping } from '@prisma/client';
 import { AlertChange, AlertChangeType, CachedAlert, WeatherAlert } from '../../types/weather';
 import { logger } from '../../utils/logger';
 
@@ -168,7 +168,7 @@ export class WeatherRepository {
     warningType?: string;
     warningLevel?: string;
     upperRegion?: string;
-  }): Promise<unknown[]> {
+  }): Promise<PrismaWeatherAlert[]> {
     const alerts = await this.prisma.weatherAlert.findMany({
       where: {
         regionId: filters?.regionId,
@@ -193,7 +193,7 @@ export class WeatherRepository {
     regionId?: string;
     warningType?: string;
     changeType?: AlertChangeType;
-  }): Promise<unknown[]> {
+  }): Promise<PrismaAlertHistory[]> {
     const histories = await this.prisma.alertHistory.findMany({
       where: {
         timestamp: { gte: filters.startDate, lte: filters.endDate },
@@ -267,7 +267,7 @@ export class WeatherRepository {
   /**
    * 지역 매핑 조회
    */
-  async getRegionMapping(regionId: string): Promise<unknown | null> {
+  async getRegionMapping(regionId: string): Promise<PrismaRegionMapping | null> {
     return this.prisma.regionMapping.findUnique({ where: { regionId } });
   }
 


### PR DESCRIPTION
## Summary

`weatherService.ts`(1920줄)에서 3개 모듈을 추출합니다.

### 추출된 모듈
- **`region-resolver.ts`** (~700줄): 지역 코드 매핑, 격자 좌표 조회, CSV 로딩, fetchRegionData, getUpperRegionName, getRegionName
- **`forecast.service.ts`** (~500줄): 초단기/동네 예보 API 호출, 데이터 합성(mergeForecastData), 체감온도 계산
- **`weather.repository.ts`** (~280줄): Prisma 쿼리 (DatabaseService에서 추출) — syncCachedAlerts, getCurrentAlerts, getAlertHistory, getAlertStatistics

> **Note**: 기존 `weatherService.ts`와 `DatabaseService.ts`는 아직 유지됩니다. Phase 6에서 새 모듈로 교체 예정.

Closes #144

## 검증

- [x] `npm run build` (tsc) 통과
- [x] `npm test` 851개 테스트 통과
- [x] Codex 코드 리뷰 2회 (P1/P2 수정 후 재리뷰)

## 코드 리뷰 결과

- 1차: P2 2건(authKey 검증, 반환 타입) + P1 1건(CSV 경로) → 수정
- 2차: P1 1건 + P2 1건 — 기존 코드의 pre-existing 이슈 (로직 변경 없이 복사). 별도 이슈로 관리 예정.